### PR TITLE
feat: GCP provider + pluggable state storage (Azure Blob / GCS) + GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+# PR checks + main/dev validation for the GitHub mirror (parallels
+# .forgejo/workflows/ci.yml). NOTE: the pytest suite's conftest OWNS the test
+# secrets (JWT_SECRET_KEY / CREDENTIAL_ENCRYPTION_KEY / *_TOKEN) and refuses to
+# run if they're set to non-test-prefixed values — so we deliberately do NOT
+# set them here; the tests use an in-memory SQLite schema built from the models.
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  api-tests:
+    name: API tests (pytest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        working-directory: services/api
+        run: pip install -e ".[dev]"
+      - name: Run tests
+        working-directory: services/api
+        run: python -m pytest tests/ -q --tb=short
+
+  ui:
+    name: UI (type-check, build, unit tests)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: services/ui/package-lock.json
+      - name: Install dependencies
+        working-directory: services/ui
+        run: npm ci
+      - name: Type-check + build
+        working-directory: services/ui
+        run: npm run build
+      - name: Unit tests
+        working-directory: services/ui
+        run: npm run test
+
+  security-scan:
+    name: Trivy IaC scan (informational)
+    runs-on: ubuntu-latest
+    # Non-blocking: surfaces HIGH/CRITICAL IaC findings without failing the PR.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Trivy (pinned + checksum-verified)
+        run: |
+          set -euo pipefail
+          TRIVY_VERSION=0.70.0
+          TRIVY_TARBALL="trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz"
+          WORKDIR="$(mktemp -d)"
+          cd "$WORKDIR"
+          curl -sfLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/${TRIVY_TARBALL}"
+          curl -sfLO "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_checksums.txt"
+          grep " ${TRIVY_TARBALL}\$" "trivy_${TRIVY_VERSION}_checksums.txt" | sha256sum -c -
+          tar -xzf "${TRIVY_TARBALL}" -C /usr/local/bin trivy
+          chmod +x /usr/local/bin/trivy
+          cd - >/dev/null
+          rm -rf "$WORKDIR"
+          trivy --version
+      - name: Trivy config scan
+        run: trivy config . --severity HIGH,CRITICAL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+# Cut a GitHub Release from a semver tag. Two ways to trigger:
+#   1. Push a tag:   git tag v0.2.0 && git push origin v0.2.0
+#   2. Actions → "Release" → Run workflow, enter a tag (created from the
+#      selected branch/ref if it doesn't already exist).
+#
+# Uses the built-in `gh` CLI + the job's GITHUB_TOKEN only — no third-party
+# actions in the release path (keeps the supply chain tight). Release notes are
+# auto-generated from merged PRs / commits since the previous tag.
+on:
+  push:
+    tags: ["v*.*.*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag, e.g. v0.2.0 (created from the selected ref if missing)"
+        required: true
+
+permissions:
+  contents: write  # create the tag (manual runs) + the release
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Resolve + ensure tag
+        id: t
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+            if ! git rev-parse "$TAG" >/dev/null 2>&1; then
+              git tag "$TAG"
+              git push origin "$TAG"
+            fi
+          else
+            TAG="${GITHUB_REF_NAME}"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+      - name: Create release (auto-generated notes)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.t.outputs.tag }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists — nothing to do."
+          else
+            gh release create "$TAG" --title "$TAG" --generate-notes
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,10 +78,21 @@ Login URL: http://localhost:3001  ·  API: http://localhost:8001  ·  Forgejo: h
   or more BUs via `user_business_units` with a per-BU `role` (operator |
   viewer). The legacy `users.role` column is still populated for one release
   as a fallback. See the Business Units section of `docs/ARCHITECTURE.md`.
-- **State backend:** S3, keyed by `{tf_working_dir}/terraform.tfstate` in a bucket
-  dedicated to the workspace's AWS account (no key prefix — isolation is via
-  per-account buckets). LocalStack in dev, AWS S3 in prod. Locking via
-  `pg_try_advisory_lock`, not DynamoDB.
+- **State backend:** pluggable per workspace via `workspaces.state_backend`
+  (`s3` default | `azureblob` | `gcs`), keyed by `{tf_working_dir}/terraform.tfstate`.
+  The executor always talks Terraform's `backend "http"` to the API; the API is
+  the only component that touches the object store, selecting the backend in
+  `routers/state.py:_service_for` (S3/Azure Blob/GCS implement the `StateStore`
+  protocol in `services/state_store.py`). `s3` uses a bucket dedicated to the
+  workspace's AWS account (LocalStack in dev); `azureblob` reuses the linked
+  Azure SP against a storage account/container; `gcs` reuses the linked GCP
+  project's SA key against a bucket. Locking is DB-side (`pg_advisory_xact_lock`),
+  backend-independent — not DynamoDB.
+- **Cloud providers:** AWS (`aws_accounts`), Azure (`azure_subscriptions`,
+  `azurerm` via `ARM_*`), and GCP (`gcp_projects`, `google` via a service-account
+  key → `GOOGLE_APPLICATION_CREDENTIALS`). Each is a per-BU-scoped vertical slice
+  (model/schema/service/router + a `CloudProviders` UI tab); a workspace links to
+  one via `aws_account_id` / `azure_subscription_id` / `gcp_project_id`.
 - **No new sky-* colors.** Sky in Tailwind is aliased to brand teal; new code
   should write `brand-*` / `accent-*` directly.
 - **Migrations are forward-only.** Alembic; one revision per change; never edit

--- a/docs/API.md
+++ b/docs/API.md
@@ -246,17 +246,48 @@ Workspaces that target `azurerm` link one of these; the executor exports
 | POST | `/azure-subscriptions` | Add a subscription (SP secret stored encrypted). | admin | BU-scoped |
 | PUT | `/azure-subscriptions/{sub_pk}` | Update name/description/location or rotate the client secret. | admin | — |
 | DELETE | `/azure-subscriptions/{sub_pk}` | Delete a subscription row. | admin | — |
-| POST | `/azure-subscriptions/{sub_pk}/test` | Validate the SP creds by requesting an ARM OAuth2 token. | admin | — |
+| POST | `/azure-subscriptions/{sub_pk}/test` | Validate the SP creds via an ARM OAuth2 token; also probes the Blob state container when configured. | admin | — |
+| POST | `/azure-subscriptions/{sub_pk}/container` | Create (or verify) the Blob state container using the SP. | admin | — |
 
 **POST /azure-subscriptions** body: `{subscription_id, tenant_id, client_id
-(all UUIDs), client_secret, name, description?, default_location?}`.
-Requires a concrete `X-Business-Unit`. `subscription_id` is unique per BU —
-duplicate → **409**.
+(all UUIDs), client_secret, name, description?, default_location?,
+state_storage_account?, state_container?}`. Requires a concrete
+`X-Business-Unit`. `subscription_id` is unique per BU — duplicate → **409**.
 
 `{sub_pk}` in the path is the TDT row id (not the Azure subscription GUID).
 Workspaces under a Git-synced repo at `azure/subscription-<guid>/<region>/<stack>`
 auto-link to the matching subscription by GUID on import — no manual picker
 needed if the subscription is already registered.
+
+Set `state_storage_account` + `state_container` to enable **Azure Blob** as a
+Terraform state backend for workspaces flagged `state_backend=azureblob` (state
+is written via the same SP over AAD — grant it *Storage Blob Data Contributor*).
+
+---
+
+## GCP Projects — `/api/v1/gcp-projects`
+
+Encrypted-at-rest GCP service-account keys, mirroring AWS Accounts / Azure
+Subscriptions. Workspaces that target the `google` provider link one of these;
+the executor writes the SA-key JSON to a 0600 file and exports
+`GOOGLE_APPLICATION_CREDENTIALS` / `GOOGLE_PROJECT` / `GOOGLE_REGION` at run time.
+
+| Method | Path | Description | Min role | BU |
+|---|---|---|---|---|
+| GET | `/gcp-projects` | List configured projects (SA key never returned; email shown). | viewer | BU-scoped |
+| POST | `/gcp-projects` | Add a project (SA-key JSON stored encrypted). | admin | BU-scoped |
+| PUT | `/gcp-projects/{project_pk}` | Update name/description/region/state bucket or rotate the SA key. | admin | — |
+| DELETE | `/gcp-projects/{project_pk}` | Delete a project row. | admin | — |
+| POST | `/gcp-projects/{project_pk}/test` | Validate the SA key by minting an access token (google-auth). | admin | — |
+| POST | `/gcp-projects/{project_pk}/bucket` | Create (or verify) the GCS state bucket using the SA key. | admin | — |
+
+**POST /gcp-projects** body: `{project_id, name, description?, default_region?,
+state_bucket?, state_prefix?, service_account_json}`. The JSON is validated
+structurally (must be a `service_account` key) and its embedded `project_id`
+must match — mismatch → **422**. `project_id` is unique per BU — duplicate → **409**.
+Set `state_bucket` to enable **GCS** as a Terraform state backend for workspaces
+flagged `state_backend=gcs`. Workspaces at `gcp/project-<id>/<region>/<stack>`
+auto-link to the matching project on import.
 
 ---
 
@@ -296,12 +327,19 @@ source path. `kind` is `terraform` (default) or `helm` — Helm workspaces
 target a `cluster_id` instead of an `aws_account_id` and skip the S3/HTTP
 state backend entirely (Helm release state lives in-cluster).
 
+`state_backend` (`s3` default | `azureblob` | `gcs`) selects where Terraform
+state is stored. `azureblob` requires a linked `azure_subscription_id` whose
+`state_storage_account`/`state_container` are set; `gcs` requires a linked
+`gcp_project_id` whose `state_bucket` is set — create/update **422** otherwise.
+`gcp_project_id` links the workspace to a GCP project (google provider), the
+mirror of `azure_subscription_id`.
+
 | Method | Path | Description | Min role | BU |
 |---|---|---|---|---|
 | GET | `/workspaces` | List workspaces. | viewer | BU-scoped |
 | GET | `/workspaces/{id}` | Get a single workspace. | viewer | BU-scoped |
 | POST | `/workspaces` | Create a workspace (manual). | admin | BU-scoped |
-| PUT | `/workspaces/{id}` | Update workspace (branch override, drift settings, `state_aws_account_id`, `azure_subscription_id`, …). | admin-tier key or interactive operator+ | BU-scoped |
+| PUT | `/workspaces/{id}` | Update workspace (branch override, drift settings, `state_aws_account_id`, `azure_subscription_id`, `gcp_project_id`, `state_backend`, …). | admin-tier key or interactive operator+ | BU-scoped |
 | POST | `/workspaces/discover` | Enumerate importable paths in a Git repo or local mount. | admin | BU-scoped |
 | POST | `/workspaces/import` | Bulk-import workspaces from a discovery result. | admin | BU-scoped |
 | GET | `/workspaces/{id}/branches` | List GitHub branches for the workspace's repo (falls back to free text if no token / non-GitHub remote). | viewer | BU-scoped |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -109,14 +109,15 @@ forward-only (`services/api/alembic/versions/NNN_*.py`).
 | Model | Table | What |
 |---|---|---|
 | `AwsAccount` | `aws_accounts` | One row per AWS account onboarded to TDT: 12-digit `account_id`, a dedicated `state_bucket`, and Fernet-encrypted access key/secret. Unique per `(business_unit_id, account_id)`. |
-| `AzureSubscription` | `azure_subscriptions` | Mirrors `AwsAccount` for Azure: `subscription_id`, `tenant_id`, `client_id` + encrypted service-principal secret. Terraform state for Azure workspaces still lives in the S3 backend (via a linked AWS account) — there's no parallel Azure Storage state backend yet. |
+| `AzureSubscription` | `azure_subscriptions` | Mirrors `AwsAccount` for Azure: `subscription_id`, `tenant_id`, `client_id` + encrypted service-principal secret. Optional `state_storage_account`/`state_container` enable an **Azure Blob** state backend (state written via the same SP over AAD) — otherwise Azure workspaces keep their state in S3. |
+| `GcpProject` | `gcp_projects` | Mirrors `AwsAccount` for GCP: `project_id`, `client_email` + Fernet-encrypted service-account key JSON. Optional `state_bucket`/`state_prefix` enable a **GCS** state backend. Unique per `(business_unit_id, project_id)`. |
 | `K8sCluster` | `k8s_clusters` | One row per Kubernetes cluster for Helm workspaces: `name`, optional `server_url`, `default_namespace`, encrypted `kubeconfig`, optional `aws_account_id` (for EKS clusters whose kubeconfig auths via `aws eks get-token`). |
 
 ### Workspaces & runs
 
 | Model | Table | What |
 |---|---|---|
-| `Workspace` | `workspaces` | One Terraform leaf module or one Helm chart. Canonical identity is `(business_unit_id, aws_account_id, region, environment, tf_working_dir)`. Carries `repo_url`/`repo_ref` (Git source), `kind` (`terraform` default or `helm`), `cluster_id` (helm target), `azure_subscription_id` (optional Azure target), `drift_status`, `path_status` (`ok`/`orphaned`/`unknown` — tracks whether the leaf still exists at `repo_ref`), `webhook_enabled`. |
+| `Workspace` | `workspaces` | One Terraform leaf module or one Helm chart. Canonical identity is `(business_unit_id, aws_account_id, region, environment, tf_working_dir)`. Carries `repo_url`/`repo_ref` (Git source), `kind` (`terraform` default or `helm`), `cluster_id` (helm target), `azure_subscription_id` / `gcp_project_id` (optional Azure/GCP targets), `state_backend` (`s3` default \| `azureblob` \| `gcs`), `drift_status`, `path_status` (`ok`/`orphaned`/`unknown` — tracks whether the leaf still exists at `repo_ref`), `webhook_enabled`. |
 | `Run` | `runs` | One plan/apply/destroy execution. FSM `status` (see [§4](#4-the-run-fsm)), captured `branch`, `plan_output`/`plan_json`, base64 `tfplan_b64` (the exact binary re-applied post-approval), encrypted `variables_encrypted` (per-run TF_VAR overrides), `policy_status`, `auto_approve_if_no_changes`/`auto_approve_skip_apply`. |
 | `RunStep` | `run_steps` | Per-step timeline row (Git Clone → Checkov → Plan → OPA → Cost → Awaiting Approval → Apply → …), kind-aware (Terraform vs. Helm step lists live in `run_step.py`). |
 | `RunArtifact` | `run_artifacts` | Blob output attached to a run (plan output, logs, checkov report). |
@@ -319,22 +320,24 @@ must be re-encrypted first. There is no fallback/default key in code —
 import time if the env var is unset, by design, so a misconfigured
 deployment fails loudly instead of silently using a predictable key.
 
-**Derivation:** each domain (AWS credentials, Azure credentials, Kubernetes
-kubeconfigs, generic `config` secrets, workspace/global variables) derives
-its **own** Fernet key from the same root key via HKDF-SHA256 with a
-**distinct, hardcoded salt** per domain (e.g.
+**Derivation:** each domain (AWS credentials, Azure credentials, GCP
+credentials, Kubernetes kubeconfigs, generic `config` secrets,
+workspace/global variables) derives its **own** Fernet key from the same root
+key via HKDF-SHA256 with a **distinct, hardcoded salt** per domain (e.g.
 `b"terraducktel-aws-credentials-v1"`, `b"terraducktel-config-v1"`,
-`b"terraducktel-azure-credentials-v1"`, `b"terraducktel-variables-v1"`).
-This means a ciphertext leaked from one domain can't be replayed or
-confused with another, and each domain can rotate its salt independently in
-a future migration without touching the root key. The pattern is identical
-everywhere it appears — `aws_account_service.py`, `azure_subscription_service.py`,
-`cluster_service.py`, `config_service.py`, `variable_service.py` — new
-encrypted domains should copy it rather than invent a new scheme.
+`b"terraducktel-azure-credentials-v1"`, `b"terraducktel-gcp-credentials-v1"`,
+`b"terraducktel-variables-v1"`). This means a ciphertext leaked from one
+domain can't be replayed or confused with another, and each domain can rotate
+its salt independently in a future migration without touching the root key.
+The pattern is identical everywhere it appears — `aws_account_service.py`,
+`azure_subscription_service.py`, `gcp_project_service.py`, `cluster_service.py`,
+`config_service.py`, `variable_service.py` — new encrypted domains should copy
+it rather than invent a new scheme.
 
 **What's encrypted:**
 - AWS access key / secret access key (`aws_accounts`).
 - Azure service-principal secret (`azure_subscriptions`).
+- GCP service-account key JSON (`gcp_projects`).
 - Kubernetes kubeconfig (`k8s_clusters`).
 - Any `config` row with `is_secret=True` (GitHub PAT, Slack bot token,
   Infracost API key, webhook secrets, `JWT_SECRET` itself once persisted).
@@ -354,20 +357,26 @@ future endpoint can't accidentally leak it.
 
 Terraform state is served by a custom **Terraform HTTP state backend**
 implemented in the API itself (`app/routers/state.py` +
-`app/services/state_service.py` + `app/services/s3_state_service.py`), not
-by pointing `terraform init` directly at S3. The executor's backend config
-points at `{API_URL}/api/v1/state/{workspace_id}`, authenticated with the
-shared `TERRADUCKTEL_STATE_TOKEN` secret.
+`app/services/state_service.py` + the pluggable object stores below), not by
+pointing `terraform init` directly at S3. The executor's backend config points
+at `{API_URL}/api/v1/state/{workspace_id}`, authenticated with the shared
+`TERRADUCKTEL_STATE_TOKEN` secret — it never learns which object store sits
+behind the API.
 
-- **Persistence**: the actual bytes live in S3 — LocalStack in dev, real AWS
-  S3 in production. **Per-account bucket isolation**: each onboarded
-  `AwsAccount` row owns its own dedicated `state_bucket`, so one account's
-  Terraform state is never physically co-located with another's, even
-  within the same BU. Non-AWS workspaces (Helm, or Azure workspaces without
-  their own state backend) still resolve to an AWS account's bucket via
-  `workspace.state_aws_account_id` — a workspace can be "grouped" outside
-  the AWS-account tree in the UI while its tfstate still lives in an S3
-  bucket owned by some account.
+- **Pluggable backends**: `workspace.state_backend` (`s3` default \|
+  `azureblob` \| `gcs`) selects the object store. `_service_for` builds a
+  `StateStore` (`app/services/state_store.py`, a Protocol with
+  `get_state_at`/`put_state_at`/`delete_state_at`) — `S3StateService`,
+  `AzureBlobStateService` (reuses the linked Azure SP over AAD), or
+  `GcsStateService` (reuses the linked GCP SA key). The HTTP interface, the
+  404-vs-503 error mapping, and locking are identical across all three.
+- **S3 persistence**: bytes live in S3 — LocalStack in dev, real AWS S3 in
+  production. **Per-account bucket isolation**: each onboarded `AwsAccount`
+  owns its own dedicated `state_bucket`, so one account's state is never
+  physically co-located with another's. Non-`s3` workspaces resolve to the
+  linked Azure subscription's container / GCP project's bucket instead. (The
+  `state_aws_account_id` override still applies to the executor's own AWS
+  cred lookup, unchanged.)
 - **Key scheme**: `{tf_working_dir}/terraform.tfstate` — the S3 key mirrors
   the workspace's git path exactly (`app/routers/state.py::_service_for`).
   Isolation between workspaces comes from the per-account dedicated bucket,

--- a/services/api/alembic/versions/038_gcp_projects.py
+++ b/services/api/alembic/versions/038_gcp_projects.py
@@ -1,0 +1,57 @@
+"""gcp_projects table — GCP as a first-class provider.
+
+Mirrors the shape of aws_accounts / azure_subscriptions (per-BU uniqueness,
+encrypted credential) so the codepaths stay parallel. Workspaces gain an
+optional FK to this table in migration 039; when set, the executor exports
+the linked project's service-account key for terraform's `google` provider,
+and a workspace may store its state in this project's GCS bucket.
+
+Revision ID: 038_gcp_projects
+Revises: 037_audit_hmac_chain
+Create Date: 2026-07-08
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "038_gcp_projects"
+down_revision = "037_audit_hmac_chain"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "gcp_projects",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("business_unit_id", sa.String(), nullable=False),
+        sa.Column("project_id", sa.String(length=64), nullable=False),
+        sa.Column("client_email", sa.String(length=255), nullable=False),
+        sa.Column("name", sa.String(length=120), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("default_region", sa.String(length=50), nullable=False, server_default="us-central1"),
+        sa.Column("state_bucket", sa.String(length=255), nullable=True),
+        sa.Column("state_prefix", sa.String(length=255), nullable=True),
+        sa.Column("service_account_json_encrypted", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "business_unit_id",
+            "project_id",
+            name="uq_gcp_projects_bu_project",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("gcp_projects")

--- a/services/api/alembic/versions/039_cloud_workspace_columns.py
+++ b/services/api/alembic/versions/039_cloud_workspace_columns.py
@@ -1,0 +1,51 @@
+"""workspaces: gcp_project_id FK + state_backend discriminator.
+
+Two related columns land together (one revision → one head):
+
+  - `gcp_project_id` — optional FK to gcp_projects (mirror of
+    azure_subscription_id in migration 026). Null = not a GCP workspace.
+  - `state_backend` — which object store holds this workspace's Terraform
+    state: "s3" (default), "azureblob", or "gcs". A `server_default="s3"`
+    backfills every existing row so behaviour is unchanged for them.
+
+Revision ID: 039_cloud_workspace_columns
+Revises: 038_gcp_projects
+Create Date: 2026-07-08
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "039_cloud_workspace_columns"
+down_revision = "038_gcp_projects"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspaces",
+        sa.Column("gcp_project_id", sa.String(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_workspaces_gcp_project",
+        "workspaces",
+        "gcp_projects",
+        ["gcp_project_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "state_backend",
+            sa.String(length=20),
+            nullable=False,
+            server_default="s3",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workspaces", "state_backend")
+    op.drop_constraint("fk_workspaces_gcp_project", "workspaces", type_="foreignkey")
+    op.drop_column("workspaces", "gcp_project_id")

--- a/services/api/alembic/versions/040_azure_state_storage.py
+++ b/services/api/alembic/versions/040_azure_state_storage.py
@@ -1,0 +1,35 @@
+"""azure_subscriptions: Azure Blob state-backend fields.
+
+Adds the storage account + container that hold Terraform state for
+workspaces flagged `state_backend=azureblob`. Both nullable — a
+provider-only subscription (state still in S3) leaves them unset. The
+existing SP creds authenticate to Blob via AAD (grant the SP "Storage
+Blob Data Contributor"); no new secret is stored.
+
+Revision ID: 040_azure_state_storage
+Revises: 039_cloud_workspace_columns
+Create Date: 2026-07-08
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "040_azure_state_storage"
+down_revision = "039_cloud_workspace_columns"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "azure_subscriptions",
+        sa.Column("state_storage_account", sa.String(length=120), nullable=True),
+    )
+    op.add_column(
+        "azure_subscriptions",
+        sa.Column("state_container", sa.String(length=120), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("azure_subscriptions", "state_container")
+    op.drop_column("azure_subscriptions", "state_storage_account")

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -23,6 +23,7 @@ from app.routers import (  # noqa: E402
     clusters,
     drift,
     environments,
+    gcp_projects,
     integrations,
     internal,
     inventory,
@@ -195,6 +196,7 @@ async def metrics_middleware(request: Request, call_next):
 app.include_router(auth.router)
 app.include_router(aws_accounts.router)
 app.include_router(azure_subscriptions.router)
+app.include_router(gcp_projects.router)
 app.include_router(integrations.router)
 app.include_router(internal.router)
 app.include_router(workspaces.router)

--- a/services/api/app/models/azure_subscription.py
+++ b/services/api/app/models/azure_subscription.py
@@ -40,6 +40,13 @@ class AzureSubscription(Base):
     name: Mapped[str] = mapped_column(String(120), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     default_location: Mapped[str] = mapped_column(String(50), nullable=False, default="eastus")
+    # Optional Azure Blob state backend. When a workspace sets
+    # state_backend=azureblob, its Terraform state is stored in this container,
+    # authenticated with the SP above via AAD (grant it "Storage Blob Data
+    # Contributor"). Both nullable = a provider-only subscription whose state
+    # still lives in S3.
+    state_storage_account: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    state_container: Mapped[str | None] = mapped_column(String(120), nullable=True)
     # Encrypted SP secret. NEVER logged, NEVER returned in API responses.
     client_secret_encrypted: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[DateTime] = mapped_column(DateTime(timezone=True), server_default=func.now())

--- a/services/api/app/models/gcp_project.py
+++ b/services/api/app/models/gcp_project.py
@@ -1,0 +1,47 @@
+"""GcpProject model — one row per GCP project onboarded to TDT.
+
+Mirrors AzureSubscription / AwsAccount: same encryption scheme (a distinct
+HKDF salt so a GCP service-account key can't be confused with an AWS or Azure
+secret), same per-BU uniqueness story, same "credentials never leave the API"
+rule. Used by workspaces that target the `google` / `google-beta` provider; the
+executor reads the SA JSON and writes it to a 0600 file, exporting the standard
+`GOOGLE_APPLICATION_CREDENTIALS` / `GOOGLE_PROJECT` env vars that terraform's
+Google provider already understands.
+
+State backends:
+  - When a workspace sets `state_backend=gcs`, its Terraform state is stored in
+    the `state_bucket` here (reusing this same SA key). Otherwise GCP workspaces
+    fall back to S3, exactly like Azure workspaces do.
+"""
+import uuid
+
+from sqlalchemy import DateTime, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db import Base
+
+
+class GcpProject(Base):
+    __tablename__ = "gcp_projects"
+
+    id: Mapped[str] = mapped_column(String, primary_key=True, default=lambda: str(uuid.uuid4()))
+    # Owning Business Unit. Same per-BU uniqueness story as aws_accounts.
+    business_unit_id: Mapped[str] = mapped_column(String, nullable=False)
+    # GCP project id — the natural key within a BU, e.g. "acme-prod-1234".
+    project_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    # Service-account email parsed from the uploaded key, for display/audit.
+    client_email: Mapped[str] = mapped_column(String(255), nullable=False)
+    # Human-readable display name (e.g. "acme-prod").
+    name: Mapped[str] = mapped_column(String(120), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    default_region: Mapped[str] = mapped_column(String(50), nullable=False, default="us-central1")
+    # Optional GCS bucket for `state_backend=gcs` workspaces. Nullable so a
+    # provider-only GCP project (state still in S3) validates fine.
+    state_bucket: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    state_prefix: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # Encrypted service-account JSON key. NEVER logged, NEVER returned in responses.
+    service_account_json_encrypted: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[DateTime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+    updated_at: Mapped[DateTime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )

--- a/services/api/app/models/workspace.py
+++ b/services/api/app/models/workspace.py
@@ -44,6 +44,22 @@ class Workspace(Base):
     azure_subscription_id: Mapped[str | None] = mapped_column(
         String, ForeignKey("azure_subscriptions.id", ondelete="SET NULL"), nullable=True
     )
+    # Optional GCP project FK. When set, the workspace targets the google
+    # provider; the executor writes the linked project's SA-key JSON to a 0600
+    # file and exports GOOGLE_APPLICATION_CREDENTIALS / GOOGLE_PROJECT. Null =
+    # not a GCP workspace.
+    gcp_project_id: Mapped[str | None] = mapped_column(
+        String, ForeignKey("gcp_projects.id", ondelete="SET NULL"), nullable=True
+    )
+    # Which object store holds this workspace's Terraform state:
+    #   "s3"        → AWS S3 (default; resolved via aws_account_id, unchanged)
+    #   "azureblob" → the linked azure_subscription's Blob container
+    #   "gcs"       → the linked gcp_project's GCS bucket
+    # Default "s3" (with a server_default) so every existing row — and any code
+    # path that doesn't set it — behaves exactly as before.
+    state_backend: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="s3", server_default="s3"
+    )
     environment: Mapped[str] = mapped_column(String(50), nullable=False)
     region: Mapped[str] = mapped_column(String(50), nullable=False, default="us-east-1")
     repo_url: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/services/api/app/routers/azure_subscriptions.py
+++ b/services/api/app/routers/azure_subscriptions.py
@@ -14,12 +14,14 @@ from app.db import get_db
 from app.models.azure_subscription import AzureSubscription
 from app.models.user import User
 from app.schemas.azure_subscription import (
+    AzureContainerResult,
     AzureSubscriptionCreate,
     AzureSubscriptionResponse,
     AzureSubscriptionTestResult,
     AzureSubscriptionUpdate,
 )
 from app.services import azure_subscription_service as svc
+from app.services.azure_blob_state_service import AzureBlobStateService
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +42,8 @@ def _to_response(sub: AzureSubscription) -> AzureSubscriptionResponse:
         name=sub.name,
         description=sub.description,
         default_location=sub.default_location,
+        state_storage_account=sub.state_storage_account,
+        state_container=sub.state_container,
         client_secret_masked=svc.mask_secret_tail(plain) if plain else "(unreadable)",
     )
 
@@ -97,6 +101,8 @@ async def create_azure_subscription(
         name=body.name,
         description=body.description,
         default_location=body.default_location,
+        state_storage_account=body.state_storage_account,
+        state_container=body.state_container,
         client_secret_encrypted=svc.encrypt_secret(body.client_secret),
     )
     db.add(sub)
@@ -181,7 +187,66 @@ async def test_azure_subscription(
                 ok=False,
                 detail=f"Token endpoint returned {resp.status_code}: {resp.text[:200]}",
             )
+        # If a Blob state container is configured, verify the SP can actually
+        # reach it (i.e. it holds Storage Blob Data Contributor) before an
+        # operator flips a workspace to state_backend=azureblob.
+        if sub.state_storage_account and sub.state_container:
+            try:
+                AzureBlobStateService.verify_container(
+                    sub.state_storage_account,
+                    sub.state_container,
+                    sub.tenant_id,
+                    sub.client_id,
+                    secret,
+                )
+            except Exception as e:  # noqa: BLE001
+                logger.warning(
+                    "Azure state container probe failed for subscription %s",
+                    sub.subscription_id,
+                    exc_info=True,
+                )
+                return AzureSubscriptionTestResult(
+                    ok=False,
+                    detail=f"SP token OK but state container unreachable: {str(e)[:150]}",
+                )
+            return AzureSubscriptionTestResult(
+                ok=True, detail="SP credentials + Blob state container validated"
+            )
         return AzureSubscriptionTestResult(ok=True, detail="SP credentials validated against ARM token endpoint")
     except Exception as e:  # noqa: BLE001
         logger.warning("Azure credential test failed for subscription %s", sub.subscription_id, exc_info=True)
         return AzureSubscriptionTestResult(ok=False, detail=str(e)[:200])
+
+
+@router.post("/{sub_pk}/container", response_model=AzureContainerResult)
+async def create_state_container(
+    sub_pk: str,
+    _: User = Depends(require_role(Role.admin)),
+    bu: BUScope = Depends(current_bu),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create (or verify) the Blob container used for this subscription's TF state."""
+    sub = await _scoped_subscription(db, sub_pk, bu)
+    if not sub.state_storage_account or not sub.state_container:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Set state_storage_account and state_container before creating the container",
+        )
+    try:
+        secret = svc.decrypt_secret(sub.client_secret_encrypted)
+        already = AzureBlobStateService.ensure_container(
+            sub.state_storage_account,
+            sub.state_container,
+            sub.tenant_id,
+            sub.client_id,
+            secret,
+        )
+        return AzureContainerResult(
+            ok=True,
+            container=sub.state_container,
+            already_existed=already,
+            detail="Container already existed" if already else "Container created",
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("Azure container create failed for subscription %s", sub.subscription_id, exc_info=True)
+        return AzureContainerResult(ok=False, container=sub.state_container, detail=str(e)[:200])

--- a/services/api/app/routers/gcp_projects.py
+++ b/services/api/app/routers/gcp_projects.py
@@ -1,0 +1,232 @@
+"""GCP project CRUD with encrypted service-account keys at rest."""
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.bu_context import BUScope, current_bu
+from app.auth.rbac import Role, require_role
+from app.db import get_db
+from app.models.gcp_project import GcpProject
+from app.models.user import User
+from app.schemas.gcp_project import (
+    GcpBucketResult,
+    GcpProjectCreate,
+    GcpProjectResponse,
+    GcpProjectTestResult,
+    GcpProjectUpdate,
+)
+from app.services import gcp_project_service as svc
+from app.services.gcs_state_service import GcsStateService
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/gcp-projects", tags=["gcp-projects"])
+
+
+def _to_response(proj: GcpProject) -> GcpProjectResponse:
+    return GcpProjectResponse(
+        id=proj.id,
+        business_unit_id=proj.business_unit_id,
+        project_id=proj.project_id,
+        client_email=proj.client_email,
+        name=proj.name,
+        description=proj.description,
+        default_region=proj.default_region,
+        state_bucket=proj.state_bucket,
+        state_prefix=proj.state_prefix,
+        service_account_masked=svc.mask_sa(proj.client_email),
+    )
+
+
+async def _scoped_project(db: AsyncSession, project_pk: str, bu: BUScope) -> GcpProject:
+    """Fetch a project by PK, enforcing the caller's BU scope (404 cross-BU)."""
+    proj = await db.get(GcpProject, project_pk)
+    if proj is None or (bu.bu_id is not None and proj.business_unit_id != bu.bu_id):
+        raise HTTPException(status_code=404, detail="GCP project not found")
+    return proj
+
+
+@router.get("", response_model=list[GcpProjectResponse])
+async def list_gcp_projects(
+    _: User = Depends(require_role(Role.viewer)),
+    bu: BUScope = Depends(current_bu),
+    db: AsyncSession = Depends(get_db),
+):
+    rows = await svc.list_projects(db, business_unit_id=bu.bu_id)
+    return [_to_response(p) for p in rows]
+
+
+@router.post("", response_model=GcpProjectResponse, status_code=status.HTTP_201_CREATED)
+async def create_gcp_project(
+    body: GcpProjectCreate,
+    _: User = Depends(require_role(Role.admin)),
+    bu: BUScope = Depends(current_bu),
+    db: AsyncSession = Depends(get_db),
+):
+    if bu.bu_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Set X-Business-Unit header to a specific BU when creating a project",
+        )
+    # The uploaded key must match the declared project_id.
+    json_project_id, client_email = svc.parse_sa_json(body.service_account_json)
+    if json_project_id and json_project_id != body.project_id:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"service-account key is for project {json_project_id!r}, "
+                f"but project_id is {body.project_id!r}"
+            ),
+        )
+    # Uniqueness within a BU on the natural key (project_id).
+    existing = (
+        await db.execute(
+            select(GcpProject).where(
+                GcpProject.business_unit_id == bu.bu_id,
+                GcpProject.project_id == body.project_id,
+            )
+        )
+    ).scalars().first()
+    if existing is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"GCP project {body.project_id} is already configured in this business unit",
+        )
+    proj = GcpProject(
+        id=str(uuid.uuid4()),
+        business_unit_id=bu.bu_id,
+        project_id=body.project_id,
+        client_email=client_email,
+        name=body.name,
+        description=body.description,
+        default_region=body.default_region,
+        state_bucket=body.state_bucket,
+        state_prefix=body.state_prefix,
+        service_account_json_encrypted=svc.encrypt_secret(body.service_account_json),
+    )
+    db.add(proj)
+    try:
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"GCP project {body.project_id} is already configured",
+        )
+    await db.refresh(proj)
+    return _to_response(proj)
+
+
+@router.put("/{project_pk}", response_model=GcpProjectResponse)
+async def update_gcp_project(
+    project_pk: str,
+    body: GcpProjectUpdate,
+    _: User = Depends(require_role(Role.admin)),
+    bu: BUScope = Depends(current_bu),
+    db: AsyncSession = Depends(get_db),
+):
+    proj = await _scoped_project(db, project_pk, bu)
+    data = body.model_dump(exclude_unset=True)
+    new_key = data.pop("service_account_json", None)
+    if new_key is not None:
+        json_project_id, client_email = svc.parse_sa_json(new_key)
+        if json_project_id and json_project_id != proj.project_id:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    f"service-account key is for project {json_project_id!r}, "
+                    f"but this row is project {proj.project_id!r}"
+                ),
+            )
+        proj.service_account_json_encrypted = svc.encrypt_secret(new_key)
+        proj.client_email = client_email
+    for k, v in data.items():
+        setattr(proj, k, v)
+    await db.commit()
+    await db.refresh(proj)
+    return _to_response(proj)
+
+
+@router.delete("/{project_pk}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_gcp_project(
+    project_pk: str,
+    _: User = Depends(require_role(Role.admin)),
+    bu: BUScope = Depends(current_bu),
+    db: AsyncSession = Depends(get_db),
+):
+    proj = await _scoped_project(db, project_pk, bu)
+    await db.delete(proj)
+    await db.commit()
+
+
+@router.post("/{project_pk}/test", response_model=GcpProjectTestResult)
+async def test_gcp_project(
+    project_pk: str,
+    _: User = Depends(require_role(Role.admin)),
+    bu: BUScope = Depends(current_bu),
+    db: AsyncSession = Depends(get_db),
+):
+    """Validate the SA key by minting an access token.
+
+    Uses google-auth if installed; falls back to a clear "not available"
+    message so credential validation never hard-crashes the endpoint.
+    """
+    proj = await _scoped_project(db, project_pk, bu)
+    try:
+        raw = svc.decrypt_secret(proj.service_account_json_encrypted)
+        try:
+            import google.auth.transport.requests
+            from google.oauth2 import service_account
+        except Exception:
+            return GcpProjectTestResult(
+                ok=False, detail="google-auth not available in API image; cannot test"
+            )
+        creds = service_account.Credentials.from_service_account_info(
+            json.loads(raw),
+            scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        )
+        creds.refresh(google.auth.transport.requests.Request())
+        return GcpProjectTestResult(
+            ok=True,
+            detail="Service-account key validated (token minted)",
+            client_email=creds.service_account_email,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("GCP credential test failed for project %s", proj.project_id, exc_info=True)
+        return GcpProjectTestResult(ok=False, detail=str(e)[:200])
+
+
+@router.post("/{project_pk}/bucket", response_model=GcpBucketResult)
+async def create_state_bucket(
+    project_pk: str,
+    _: User = Depends(require_role(Role.admin)),
+    bu: BUScope = Depends(current_bu),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create (or verify) the GCS bucket used for this project's TF state."""
+    proj = await _scoped_project(db, project_pk, bu)
+    if not proj.state_bucket:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Set state_bucket on this project before creating it",
+        )
+    try:
+        raw = svc.decrypt_secret(proj.service_account_json_encrypted)
+        already = GcsStateService.ensure_bucket(
+            proj.state_bucket, raw, proj.project_id, proj.default_region
+        )
+        return GcpBucketResult(
+            ok=True,
+            bucket=proj.state_bucket,
+            already_existed=already,
+            detail="Bucket already existed" if already else "Bucket created",
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning("GCS bucket create failed for project %s", proj.project_id, exc_info=True)
+        return GcpBucketResult(ok=False, bucket=proj.state_bucket, detail=str(e)[:200])

--- a/services/api/app/routers/state.py
+++ b/services/api/app/routers/state.py
@@ -23,10 +23,17 @@ def _check_state_scope(auth: StateAuth, workspace_id: str) -> None:
         )
 from app.db import get_db
 from app.models.workspace import Workspace
+from app.models.azure_subscription import AzureSubscription
+from app.models.gcp_project import GcpProject
 from app.services.state_service import StateLockService
+from app.services.state_store import StateStore
 from app.services.s3_state_service import S3StateService
+from app.services.azure_blob_state_service import AzureBlobStateService
+from app.services.gcs_state_service import GcsStateService
 from app.services.secret_scanner import scan_terraform_state_json
 from app.services import aws_account_service as accs
+from app.services import azure_subscription_service as azsvc
+from app.services import gcp_project_service as gcpsvc
 
 logger = logging.getLogger(__name__)
 
@@ -40,13 +47,25 @@ _FALLBACK_BUCKET = os.environ.get("S3_STATE_BUCKET", "terraducktel-state")
 _S3_REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
 
 
-async def _service_for(ws: Workspace, db: AsyncSession) -> tuple[S3StateService, str]:
-    """Return (S3 client bound to the workspace's AwsAccount, key for the leaf path).
-
-    The state key mirrors the workspace's `tf_working_dir` exactly so the file
-    layout in S3 matches the layout in git: e.g.
+def _state_key_for(ws: Workspace) -> str:
+    """State object key = the workspace's leaf path, so the layout in the
+    object store mirrors the layout in git: e.g.
         account-111111111111/eu-central-1/region-shared-resources/terraform.tfstate
-    Each AWS account has its own bucket — never shared.
+    Identical across every backend (S3 key / Azure blob name / GCS object).
+    """
+    leaf_path = (ws.tf_working_dir or ".").strip("/")
+    if leaf_path in ("", "."):
+        leaf_path = ws.name
+    return f"{leaf_path}/terraform.tfstate"
+
+
+async def _s3_store_for(ws: Workspace, db: AsyncSession) -> StateStore:
+    """S3 backend — resolves the bucket via the workspace's AwsAccount.
+
+    Unchanged behaviour: uses `ws.aws_account_id` (NOT state_aws_account_id —
+    that override lives only in the executor cred path). Each AWS account has
+    its own bucket; falls back to the env-configured shared bucket (LocalStack
+    in dev) when no AwsAccount is registered.
     """
     account = await accs.get_account_by_account_id(db, ws.aws_account_id)
     if account is not None:
@@ -54,24 +73,69 @@ async def _service_for(ws: Workspace, db: AsyncSession) -> tuple[S3StateService,
         # only applies to the legacy env-default fallback below.
         access_key = accs.decrypt_secret(account.access_key_id_encrypted)
         secret_key = accs.decrypt_secret(account.secret_access_key_encrypted)
-        svc = S3StateService(
+        return S3StateService(
             bucket=account.state_bucket,
             use_localstack=False,
             region=account.state_bucket_region,
             access_key_id=access_key,
             secret_access_key=secret_key,
         )
+    return S3StateService(
+        bucket=_FALLBACK_BUCKET, use_localstack=_USE_LOCALSTACK, region=_S3_REGION
+    )
+
+
+async def _azure_store_for(ws: Workspace, db: AsyncSession) -> StateStore:
+    """Azure Blob backend — reuses the linked subscription's SP creds (AAD)."""
+    if not ws.azure_subscription_id:
+        raise RuntimeError("state_backend=azureblob but workspace has no azure_subscription_id")
+    sub = await db.get(AzureSubscription, ws.azure_subscription_id)
+    if sub is None or not sub.state_storage_account or not sub.state_container:
+        raise RuntimeError("linked Azure subscription has no state storage account/container")
+    secret = azsvc.decrypt_secret(sub.client_secret_encrypted)
+    return AzureBlobStateService(
+        storage_account=sub.state_storage_account,
+        container=sub.state_container,
+        tenant_id=sub.tenant_id,
+        client_id=sub.client_id,
+        client_secret=secret,
+    )
+
+
+async def _gcs_store_for(ws: Workspace, db: AsyncSession) -> StateStore:
+    """GCS backend — reuses the linked project's service-account JSON key."""
+    if not ws.gcp_project_id:
+        raise RuntimeError("state_backend=gcs but workspace has no gcp_project_id")
+    proj = await db.get(GcpProject, ws.gcp_project_id)
+    if proj is None or not proj.state_bucket:
+        raise RuntimeError("linked GCP project has no state bucket")
+    sa_json = gcpsvc.decrypt_secret(proj.service_account_json_encrypted)
+    return GcsStateService(
+        bucket=proj.state_bucket,
+        service_account_json=sa_json,
+        project_id=proj.project_id,
+        prefix=proj.state_prefix or "",
+    )
+
+
+async def _service_for(ws: Workspace, db: AsyncSession) -> tuple[StateStore, str]:
+    """Return (state store for the workspace's backend, key for the leaf path).
+
+    The backend is chosen by `ws.state_backend` (default "s3"). The HTTP
+    interface and the executor's `backend "http"` wiring are identical across
+    backends — Terraform never learns which object store sits behind the API.
+    A store that cannot be built (missing linkage/fields) raises, which the GET
+    handler maps to 503 ("backend unavailable") — the correct signal, and safer
+    than silently writing state to the wrong place.
+    """
+    backend = (getattr(ws, "state_backend", None) or "s3").lower()
+    if backend == "azureblob":
+        store = await _azure_store_for(ws, db)
+    elif backend == "gcs":
+        store = await _gcs_store_for(ws, db)
     else:
-        # Backward-compat: workspace without a registered AwsAccount falls back
-        # to the env-configured shared bucket (LocalStack in dev).
-        svc = S3StateService(
-            bucket=_FALLBACK_BUCKET, use_localstack=_USE_LOCALSTACK, region=_S3_REGION
-        )
-    leaf_path = (ws.tf_working_dir or ".").strip("/")
-    if leaf_path in ("", "."):
-        leaf_path = ws.name
-    key = f"{leaf_path}/terraform.tfstate"
-    return svc, key
+        store = await _s3_store_for(ws, db)
+    return store, _state_key_for(ws)
 
 
 @router.get("/{workspace_id}")
@@ -102,7 +166,7 @@ async def get_state(
         svc, key = await _service_for(ws, db)
         data = svc.get_state_at(key)
     except Exception:
-        logger.exception("S3 state fetch failed for workspace %s", workspace_id)
+        logger.exception("State fetch failed for workspace %s", workspace_id)
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="State backend unavailable",
@@ -166,8 +230,8 @@ async def put_state(
         svc, key = await _service_for(ws, db)
         svc.put_state_at(key, body)
     except Exception:
-        logger.exception("Failed to persist state to S3 for workspace %s", workspace_id)
-        raise HTTPException(status_code=500, detail="Failed to persist state to S3")
+        logger.exception("Failed to persist state for workspace %s", workspace_id)
+        raise HTTPException(status_code=500, detail="Failed to persist state")
 
     return Response(status_code=200)
 

--- a/services/api/app/routers/workspaces.py
+++ b/services/api/app/routers/workspaces.py
@@ -33,6 +33,11 @@ _GITHUB_OWNER_REPO_RE = re.compile(
 # so we derive + auto-link it on import instead of asking the user to pick one.
 _AZURE_SUB_RE = re.compile(r"^subscription-([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$")
 
+# GCP leaves live under `gcp/project-<project_id>/<region>/<stack>` — the
+# project id is encoded in the path (like the AWS account / Azure subscription),
+# so we derive + auto-link it on import instead of asking the user to pick one.
+_GCP_PROJECT_RE = re.compile(r"^project-([a-z][a-z0-9-]{4,28}[a-z0-9])$")
+
 
 async def _commit_or_conflict(
     db: AsyncSession,
@@ -75,6 +80,16 @@ def _azure_sub_guid_from_path(path: str) -> str | None:
         if m:
             return m.group(1)
     return None
+
+
+def _gcp_project_id_from_path(path: str) -> str | None:
+    """Extract the GCP project id from a `gcp/project-<id>/…` path."""
+    parts = [p for p in (path or "").split("/") if p]
+    if len(parts) >= 2 and parts[0].lower() == "gcp":
+        m = _GCP_PROJECT_RE.match(parts[1])
+        if m:
+            return m.group(1)
+    return None
 from app.schemas.workspace import (
     BulkImportRequest,
     BulkImportResult,
@@ -90,6 +105,43 @@ from app.services import repo_discovery
 from app.services import api_key_service
 
 router = APIRouter(prefix="/api/v1/workspaces", tags=["workspaces"])
+
+
+async def _validate_state_backend_linkage(
+    db: AsyncSession,
+    state_backend: str,
+    azure_sub_pk: str | None,
+    gcp_project_pk: str | None,
+) -> None:
+    """Ensure the chosen state_backend has its required cloud linkage + storage
+    target, so the executor's HTTP-state calls resolve at run time. Raises
+    HTTPException(422) otherwise. "s3" needs nothing extra."""
+    if state_backend == "azureblob":
+        from app.models.azure_subscription import AzureSubscription
+
+        sub = await db.get(AzureSubscription, azure_sub_pk) if azure_sub_pk else None
+        if sub is None or not sub.state_storage_account or not sub.state_container:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "state_backend=azureblob requires a linked azure_subscription_id "
+                    "whose state_storage_account and state_container are set "
+                    "(configure them in Settings → Cloud Providers → Azure)."
+                ),
+            )
+    elif state_backend == "gcs":
+        from app.models.gcp_project import GcpProject
+
+        proj = await db.get(GcpProject, gcp_project_pk) if gcp_project_pk else None
+        if proj is None or not proj.state_bucket:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    "state_backend=gcs requires a linked gcp_project_id whose "
+                    "state_bucket is set (configure it in Settings → Cloud "
+                    "Providers → GCP)."
+                ),
+            )
 
 
 @router.get("", response_model=list[WorkspaceResponse])
@@ -195,6 +247,29 @@ async def create_workspace(
             )
         azure_sub_pk = sub.id
 
+    # Optional GCP project link: must belong to the same BU.
+    gcp_project_pk: str | None = None
+    if body.gcp_project_id:
+        from app.models.gcp_project import GcpProject
+
+        proj = await db.get(GcpProject, body.gcp_project_id)
+        if proj is None or proj.business_unit_id != bu.bu_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"GCP project {body.gcp_project_id} is not configured "
+                    f"in this business unit"
+                ),
+            )
+        gcp_project_pk = proj.id
+
+    # The chosen state backend must have its required cloud linkage + storage
+    # target, or the executor's HTTP-state calls would 503 at run time.
+    state_backend = body.state_backend or "s3"
+    await _validate_state_backend_linkage(
+        db, state_backend, azure_sub_pk, gcp_project_pk
+    )
+
     ws = Workspace(
         id=str(uuid.uuid4()),
         business_unit_id=bu.bu_id,
@@ -209,6 +284,8 @@ async def create_workspace(
         kind=body.kind,
         cluster_id=body.cluster_id,
         azure_subscription_id=azure_sub_pk,
+        gcp_project_id=gcp_project_pk,
+        state_backend=state_backend,
     )
     db.add(ws)
     await _commit_or_conflict(
@@ -292,6 +369,24 @@ async def update_workspace(
     elif az_override == "":
         update_data["azure_subscription_id"] = None
 
+    # gcp_project_id: same semantics as azure_subscription_id — empty string
+    # clears, a value must reference a project in the same BU.
+    gcp_override = update_data.get("gcp_project_id")
+    if gcp_override:
+        from app.models.gcp_project import GcpProject
+
+        proj = await db.get(GcpProject, gcp_override)
+        if proj is None or proj.business_unit_id != ws.business_unit_id:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"gcp_project_id '{gcp_override}' is not a registered "
+                    f"GCP project in this Business Unit."
+                ),
+            )
+    elif gcp_override == "":
+        update_data["gcp_project_id"] = None
+
     # aws_account_id: create validates this against the BU, but update used to
     # blind-setattr it — letting an operator point their workspace at an account
     # registered only in ANOTHER BU. Validate it the same way create
@@ -314,6 +409,23 @@ async def update_workspace(
                     f"account in this Business Unit."
                 ),
             )
+
+    # If the state backend is (being) set to a cloud store, validate the
+    # EFFECTIVE linkage after applying the above overrides — the backend and
+    # the linkage can change in the same request.
+    effective_backend = update_data.get("state_backend") or ws.state_backend
+    if effective_backend in ("azureblob", "gcs"):
+        eff_azure = (
+            update_data["azure_subscription_id"]
+            if "azure_subscription_id" in update_data
+            else ws.azure_subscription_id
+        )
+        eff_gcp = (
+            update_data["gcp_project_id"]
+            if "gcp_project_id" in update_data
+            else ws.gcp_project_id
+        )
+        await _validate_state_backend_linkage(db, effective_backend, eff_azure, eff_gcp)
 
     for field, value in update_data.items():
         setattr(ws, field, value)
@@ -460,6 +572,17 @@ async def bulk_import(
             )
         ).scalars().all()
     }
+    # Same for GCP projects: gcp leaves auto-link by the project id in their path.
+    from app.models.gcp_project import GcpProject
+
+    gcp_by_project_id = {
+        p.project_id: p.id
+        for p in (
+            await db.execute(
+                select(GcpProject).where(GcpProject.business_unit_id == bu.bu_id)
+            )
+        ).scalars().all()
+    }
 
     created: list[Workspace] = []
     skipped: list[dict] = []
@@ -511,6 +634,12 @@ async def bulk_import(
         _guid = _azure_sub_guid_from_path(entry.path)
         if _guid and _guid in az_by_guid:
             ws.azure_subscription_id = az_by_guid[_guid]
+        # Same for GCP leaves (gcp/project-<id>/…). Unregistered projects stay
+        # unlinked; the operator can register + relink later. State backend
+        # stays "s3" on import — an operator opts a workspace into GCS explicitly.
+        _gcp_pid = _gcp_project_id_from_path(entry.path)
+        if _gcp_pid and _gcp_pid in gcp_by_project_id:
+            ws.gcp_project_id = gcp_by_project_id[_gcp_pid]
         db.add(ws)
         created.append(ws)
     if created:

--- a/services/api/app/schemas/azure_subscription.py
+++ b/services/api/app/schemas/azure_subscription.py
@@ -16,6 +16,13 @@ class AzureSubscriptionCreate(BaseModel):
     name: str = Field(..., min_length=1, max_length=120)
     description: Optional[str] = None
     default_location: str = Field(default="eastus", min_length=1, max_length=50)
+    # Optional Azure Blob state backend (for workspaces flagged
+    # state_backend=azureblob). Storage account: 3-24 lowercase alnum.
+    # Container: 3-63, lowercase alnum + hyphens, no leading/trailing hyphen.
+    state_storage_account: Optional[str] = Field(default=None, pattern=r"^[a-z0-9]{3,24}$")
+    state_container: Optional[str] = Field(
+        default=None, pattern=r"^[a-z0-9]([a-z0-9-]{1,61}[a-z0-9])$"
+    )
 
     @field_validator("subscription_id", "tenant_id", "client_id")
     @classmethod
@@ -27,6 +34,8 @@ class AzureSubscriptionUpdate(BaseModel):
     name: Optional[str] = Field(default=None, min_length=1, max_length=120)
     description: Optional[str] = None
     default_location: Optional[str] = None
+    state_storage_account: Optional[str] = None
+    state_container: Optional[str] = None
     # If client_secret is provided we re-encrypt it on the server.
     client_secret: Optional[str] = None
 
@@ -45,6 +54,8 @@ class AzureSubscriptionResponse(BaseModel):
     name: str
     description: Optional[str] = None
     default_location: str
+    state_storage_account: Optional[str] = None
+    state_container: Optional[str] = None
     client_secret_masked: str
 
     model_config = {"from_attributes": False}
@@ -53,3 +64,10 @@ class AzureSubscriptionResponse(BaseModel):
 class AzureSubscriptionTestResult(BaseModel):
     ok: bool
     detail: Optional[str] = None
+
+
+class AzureContainerResult(BaseModel):
+    ok: bool
+    detail: Optional[str] = None
+    container: Optional[str] = None
+    already_existed: bool = False

--- a/services/api/app/schemas/gcp_project.py
+++ b/services/api/app/schemas/gcp_project.py
@@ -1,0 +1,91 @@
+"""Pydantic schemas for GcpProject."""
+import json
+from typing import Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+# GCP project ids: 6-30 chars, start with a lowercase letter, then lowercase
+# letters / digits / hyphens, no trailing hyphen.
+_PROJECT_ID_PATTERN = r"^[a-z][a-z0-9-]{4,28}[a-z0-9]$"
+
+
+def _validate_sa_json(v: str) -> str:
+    """Structurally validate an uploaded service-account key JSON."""
+    try:
+        data = json.loads(v)
+    except (json.JSONDecodeError, ValueError):
+        raise ValueError("service_account_json must be valid JSON")
+    if not isinstance(data, dict):
+        raise ValueError("service_account_json must be a JSON object")
+    if data.get("type") != "service_account":
+        raise ValueError('service_account_json must have "type": "service_account"')
+    for field in ("client_email", "private_key", "project_id"):
+        if not data.get(field):
+            raise ValueError(f"service_account_json missing required field: {field}")
+    return v
+
+
+class GcpProjectCreate(BaseModel):
+    project_id: str = Field(..., pattern=_PROJECT_ID_PATTERN)
+    name: str = Field(..., min_length=1, max_length=120)
+    description: Optional[str] = None
+    default_region: str = Field(default="us-central1", min_length=1, max_length=50)
+    # Optional GCS state bucket (for workspaces flagged state_backend=gcs).
+    state_bucket: Optional[str] = Field(default=None, max_length=255)
+    state_prefix: Optional[str] = Field(default=None, max_length=255)
+    # The full service-account key JSON (pasted from the downloaded key file).
+    # Validated structurally here; encrypted at rest by the service layer.
+    service_account_json: str = Field(..., min_length=50)
+
+    @field_validator("service_account_json")
+    @classmethod
+    def _sa(cls, v: str) -> str:
+        return _validate_sa_json(v)
+
+
+class GcpProjectUpdate(BaseModel):
+    name: Optional[str] = Field(default=None, min_length=1, max_length=120)
+    description: Optional[str] = None
+    default_region: Optional[str] = None
+    state_bucket: Optional[str] = None
+    state_prefix: Optional[str] = None
+    # If provided, re-encrypted on the server.
+    service_account_json: Optional[str] = None
+
+    @field_validator("service_account_json")
+    @classmethod
+    def _sa(cls, v: Optional[str]) -> Optional[str]:
+        return _validate_sa_json(v) if v is not None else v
+
+
+class GcpProjectResponse(BaseModel):
+    """Response shape — NEVER returns the plaintext SA key JSON.
+
+    `service_account_masked` is the SA client_email (already low-sensitivity,
+    it's an identifier) so admins can tell which SA is configured.
+    """
+    id: str
+    business_unit_id: str
+    project_id: str
+    client_email: str
+    name: str
+    description: Optional[str] = None
+    default_region: str
+    state_bucket: Optional[str] = None
+    state_prefix: Optional[str] = None
+    service_account_masked: str
+
+    model_config = {"from_attributes": False}
+
+
+class GcpProjectTestResult(BaseModel):
+    ok: bool
+    detail: Optional[str] = None
+    client_email: Optional[str] = None
+
+
+class GcpBucketResult(BaseModel):
+    ok: bool
+    detail: Optional[str] = None
+    bucket: Optional[str] = None
+    already_existed: bool = False

--- a/services/api/app/schemas/workspace.py
+++ b/services/api/app/schemas/workspace.py
@@ -19,6 +19,21 @@ def _validate_kind(value: str) -> str:
     return value
 
 
+# Allowed Terraform state backends. "s3" (default) resolves via aws_account_id;
+# "azureblob" uses the linked azure_subscription's Blob container; "gcs" uses
+# the linked gcp_project's GCS bucket. The API validates the required linkage
+# on create/update (routers/workspaces.py).
+_STATE_BACKENDS = {"s3", "azureblob", "gcs"}
+
+
+def _validate_state_backend(value: str) -> str:
+    if value not in _STATE_BACKENDS:
+        raise ValueError(
+            f"state_backend must be one of {sorted(_STATE_BACKENDS)}, got {value!r}"
+        )
+    return value
+
+
 def _validate_repo_url(value: Optional[str]) -> Optional[str]:
     """Reject git transport-helper URLs.
 
@@ -76,11 +91,21 @@ class WorkspaceCreate(BaseModel):
     # exports ARM_* env vars from the linked subscription's encrypted SP
     # credentials. State backend continues to be S3 for now.
     azure_subscription_id: Optional[str] = None
+    # Optional GCP project FK. When set, the workspace targets the google
+    # provider; the executor exports the linked project's SA-key credentials.
+    gcp_project_id: Optional[str] = None
+    # Where Terraform state is stored: "s3" (default), "azureblob", or "gcs".
+    state_backend: str = "s3"
 
     @field_validator("kind")
     @classmethod
     def _kind_in_allowed(cls, value: str) -> str:
         return _validate_kind(value)
+
+    @field_validator("state_backend")
+    @classmethod
+    def _state_backend_in_allowed(cls, value: str) -> str:
+        return _validate_state_backend(value)
 
     @field_validator("repo_url")
     @classmethod
@@ -108,6 +133,16 @@ class WorkspaceUpdate(BaseModel):
     # Pass null (or omit) to leave unchanged; pass empty string to clear;
     # pass a value to relink to a different subscription.
     azure_subscription_id: Optional[str] = None
+    # Same semantics as azure_subscription_id, for the GCP linkage.
+    gcp_project_id: Optional[str] = None
+    # Change where state is stored: "s3", "azureblob", or "gcs". The router
+    # validates the required cloud linkage before applying the change.
+    state_backend: Optional[str] = None
+
+    @field_validator("state_backend")
+    @classmethod
+    def _state_backend_in_allowed(cls, value: Optional[str]) -> Optional[str]:
+        return _validate_state_backend(value) if value is not None else value
 
     @field_validator("repo_url")
     @classmethod
@@ -139,6 +174,10 @@ class WorkspaceResponse(BaseModel):
     state_aws_account_id: Optional[str] = None
     # The PK of the linked azure_subscriptions row, or null for AWS-only.
     azure_subscription_id: Optional[str] = None
+    # The PK of the linked gcp_projects row, or null if not a GCP workspace.
+    gcp_project_id: Optional[str] = None
+    # Where Terraform state is stored: "s3" (default), "azureblob", or "gcs".
+    state_backend: str = "s3"
     created_at: Optional[datetime] = None
 
     model_config = {"from_attributes": True}

--- a/services/api/app/services/azure_blob_state_service.py
+++ b/services/api/app/services/azure_blob_state_service.py
@@ -1,0 +1,104 @@
+"""Azure Blob Storage backend for Terraform state.
+
+Implements the ``StateStore`` protocol. Authenticates with the *same* Azure
+service principal already stored on the workspace's `azure_subscriptions` row
+(reused via AAD) — no separate storage secret. The SP must hold the
+**Storage Blob Data Contributor** role on the target storage account/container.
+
+The blob name is the workspace's ``{tf_working_dir}/terraform.tfstate`` key
+verbatim, so the layout in Blob mirrors the layout in git and in S3.
+
+The Azure SDK is imported lazily inside each method/ctor so the S3-only boot
+path never requires the `azure-*` wheels to be installed.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+
+def _blob_service(storage_account: str, tenant_id: str, client_id: str, client_secret: str):
+    from azure.identity import ClientSecretCredential
+    from azure.storage.blob import BlobServiceClient
+
+    credential = ClientSecretCredential(
+        tenant_id=tenant_id, client_id=client_id, client_secret=client_secret
+    )
+    return BlobServiceClient(
+        account_url=f"https://{storage_account}.blob.core.windows.net",
+        credential=credential,
+    )
+
+
+class AzureBlobStateService:
+    """StateStore backed by an Azure Blob container (AAD / service-principal auth)."""
+
+    def __init__(
+        self,
+        storage_account: str,
+        container: str,
+        tenant_id: str,
+        client_id: str,
+        client_secret: str,
+    ):
+        self._service = _blob_service(storage_account, tenant_id, client_id, client_secret)
+        self._container = container
+
+    def get_state_at(self, key: str) -> Optional[bytes]:
+        from azure.core.exceptions import ResourceNotFoundError
+
+        blob = self._service.get_blob_client(self._container, key)
+        try:
+            return blob.download_blob().readall()
+        except ResourceNotFoundError:
+            return None
+
+    def put_state_at(self, key: str, state_bytes: bytes) -> None:
+        # Azure Blob is encrypted at rest with Microsoft-managed keys by
+        # default — no explicit SSE parameter (that is an S3-only concept).
+        blob = self._service.get_blob_client(self._container, key)
+        blob.upload_blob(state_bytes, overwrite=True)
+
+    def delete_state_at(self, key: str) -> bool:
+        from azure.core.exceptions import ResourceNotFoundError
+
+        blob = self._service.get_blob_client(self._container, key)
+        try:
+            blob.delete_blob()
+            return True
+        except ResourceNotFoundError:
+            return True
+
+    # ------------------------------------------------------------------
+    # Admin helpers (used by the azure-subscriptions router /container + /test)
+    # ------------------------------------------------------------------
+    @staticmethod
+    def ensure_container(
+        storage_account: str,
+        container: str,
+        tenant_id: str,
+        client_id: str,
+        client_secret: str,
+    ) -> bool:
+        """Create the container if absent. Returns True if it already existed."""
+        from azure.core.exceptions import ResourceExistsError
+
+        service = _blob_service(storage_account, tenant_id, client_id, client_secret)
+        try:
+            service.create_container(container)
+            return False
+        except ResourceExistsError:
+            return True
+
+    @staticmethod
+    def verify_container(
+        storage_account: str,
+        container: str,
+        tenant_id: str,
+        client_id: str,
+        client_secret: str,
+    ) -> None:
+        """Raise if the SP cannot read the container (used by /test to confirm
+        the SP has Storage Blob Data Contributor before a workspace is flipped
+        to ``state_backend=azureblob``)."""
+        service = _blob_service(storage_account, tenant_id, client_id, client_secret)
+        service.get_container_client(container).get_container_properties()

--- a/services/api/app/services/azure_subscription_service.py
+++ b/services/api/app/services/azure_subscription_service.py
@@ -92,3 +92,23 @@ async def get_subscription_credentials(
         sub.client_id,
         decrypt_secret(sub.client_secret_encrypted),
     )
+
+
+async def get_state_storage(
+    session: AsyncSession, sub_pk: str
+) -> tuple[str, str, str, str, str] | None:
+    """Return (storage_account, container, tenant_id, client_id, client_secret).
+
+    Used by the Azure Blob state backend + the /container admin endpoint.
+    Returns None if the subscription is missing or has no storage configured.
+    """
+    sub = await get_subscription(session, sub_pk)
+    if sub is None or not sub.state_storage_account or not sub.state_container:
+        return None
+    return (
+        sub.state_storage_account,
+        sub.state_container,
+        sub.tenant_id,
+        sub.client_id,
+        decrypt_secret(sub.client_secret_encrypted),
+    )

--- a/services/api/app/services/executor_service.py
+++ b/services/api/app/services/executor_service.py
@@ -298,10 +298,51 @@ class ExecutorService:
                     "ARM_TENANT_ID": tenant_id,
                     "ARM_CLIENT_ID": client_id,
                     "ARM_CLIENT_SECRET": client_secret,
-                    # Tells the executor entrypoint which provider mix to expect.
-                    # Unset for AWS-only workspaces — entrypoint defaults to AWS.
-                    "TDT_CLOUD_PROVIDERS": "aws,azure" if aws_key else "azure",
                 })
+
+        # GCP: if the workspace is linked to a GCP project, pass the SA-key JSON
+        # (the entrypoint writes it to a 0600 file and exports
+        # GOOGLE_APPLICATION_CREDENTIALS) plus GOOGLE_PROJECT / GOOGLE_REGION so
+        # the terraform google provider authenticates.
+        gcp_project_pk = getattr(workspace, "gcp_project_id", None)
+        if gcp_project_pk and db_session is not None:
+            try:
+                from app.services import gcp_project_service as gcpsvc
+
+                gcp_creds = await gcpsvc.get_project_credentials(db_session, gcp_project_pk)
+                gcp_row = await gcpsvc.get_project(db_session, gcp_project_pk)
+            except Exception:
+                logger.warning(
+                    "Failed to load GCP SA creds for project %s — workspace %s will "
+                    "fall back to environment auth (likely fails).",
+                    gcp_project_pk, workspace.id, exc_info=True,
+                )
+                gcp_creds = None
+                gcp_row = None
+            if gcp_creds is not None:
+                project_id, sa_json = gcp_creds
+                gcp_region = (
+                    (getattr(gcp_row, "default_region", None) or "").strip()
+                    or workspace.region
+                )
+                environment.update({
+                    "GCP_SA_KEY_JSON": sa_json,
+                    "GOOGLE_PROJECT": project_id,
+                    "GOOGLE_REGION": gcp_region,
+                })
+
+        # Tell the executor entrypoint which provider mix to expect — composed
+        # from whatever creds actually got wired in above. Unset only when the
+        # workspace has no cloud creds at all (entrypoint then defaults to AWS).
+        _providers = []
+        if aws_key:
+            _providers.append("aws")
+        if environment.get("ARM_CLIENT_ID"):
+            _providers.append("azure")
+        if environment.get("GCP_SA_KEY_JSON"):
+            _providers.append("gcp")
+        if _providers:
+            environment["TDT_CLOUD_PROVIDERS"] = ",".join(_providers)
 
         # Merge global → workspace → run variables and inject as TF_VAR_<key>.
         # Terraform parses TF_VAR_* values starting with `[` or `{` as HCL,

--- a/services/api/app/services/gcp_project_service.py
+++ b/services/api/app/services/gcp_project_service.py
@@ -1,0 +1,91 @@
+"""Service layer for GcpProject.
+
+Shares the same Fernet/HKDF crypto context as the other cloud-account services
+— a distinct HKDF ``salt`` derives an independent Fernet key so a GCP SA key
+cannot be confused with an AWS access key or an Azure SP secret even if a row's
+ciphertext were swapped at the DB level. Uses the fail-loud
+``get_credential_encryption_key()`` helper (parity with aws_account_service).
+"""
+from __future__ import annotations
+
+import base64
+import json
+from typing import Optional
+
+from cryptography.exceptions import InvalidKey
+from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.encryption_key import get_credential_encryption_key
+from app.models.gcp_project import GcpProject
+
+
+def _fernet() -> Fernet:
+    key = get_credential_encryption_key()
+    if len(key) < 16:
+        raise RuntimeError("CREDENTIAL_ENCRYPTION_KEY must be at least 16 bytes")
+    try:
+        derived = HKDF(
+            algorithm=hashes.SHA256(),
+            length=32,
+            salt=b"terraducktel-gcp-credentials-v1",
+            info=b"fernet-key",
+        ).derive(key)
+    except InvalidKey as e:  # pragma: no cover — HKDF.derive can't currently raise for valid lens
+        raise RuntimeError("HKDF derivation failed for GCP credentials") from e
+    return Fernet(base64.urlsafe_b64encode(derived))
+
+
+def encrypt_secret(value: str) -> str:
+    return _fernet().encrypt(value.encode("utf-8")).decode("utf-8")
+
+
+def decrypt_secret(value: str) -> str:
+    try:
+        return _fernet().decrypt(value.encode("utf-8")).decode("utf-8")
+    except InvalidToken as e:
+        raise RuntimeError("GCP credential decryption failed") from e
+
+
+def parse_sa_json(raw: str) -> tuple[str, str]:
+    """Return (project_id, client_email) from a service-account key JSON.
+
+    Assumes the JSON already passed schema validation (GcpProjectCreate).
+    """
+    data = json.loads(raw)
+    return data.get("project_id", ""), data.get("client_email", "")
+
+
+def mask_sa(client_email: str) -> str:
+    """The SA email is an identifier, not a secret — surface it directly."""
+    return client_email or "(unknown)"
+
+
+async def list_projects(
+    session: AsyncSession, business_unit_id: Optional[str] = None
+) -> list[GcpProject]:
+    stmt = select(GcpProject).order_by(GcpProject.name)
+    if business_unit_id is not None:
+        stmt = stmt.where(GcpProject.business_unit_id == business_unit_id)
+    return list((await session.execute(stmt)).scalars().all())
+
+
+async def get_project(session: AsyncSession, project_pk: str) -> Optional[GcpProject]:
+    return await session.get(GcpProject, project_pk)
+
+
+async def get_project_credentials(
+    session: AsyncSession, project_pk: str
+) -> tuple[str, str] | None:
+    """Return (project_id, service_account_json) plaintext.
+
+    Used at run-time only by the executor service so it can write the SA key to
+    a 0600 file and export GOOGLE_APPLICATION_CREDENTIALS / GOOGLE_PROJECT.
+    """
+    proj = await get_project(session, project_pk)
+    if proj is None:
+        return None
+    return (proj.project_id, decrypt_secret(proj.service_account_json_encrypted))

--- a/services/api/app/services/gcs_state_service.py
+++ b/services/api/app/services/gcs_state_service.py
@@ -1,0 +1,99 @@
+"""Google Cloud Storage backend for Terraform state.
+
+Implements the ``StateStore`` protocol. Authenticates with the *same*
+service-account JSON key already stored on the workspace's `gcp_projects` row
+(reused) — no separate storage secret. The SA must hold
+``roles/storage.objectAdmin`` (or finer) on the target bucket.
+
+The object name is the workspace's ``{tf_working_dir}/terraform.tfstate`` key
+verbatim, optionally under a configured prefix, so the layout mirrors git/S3.
+
+The Google SDK is imported lazily so the S3-only boot path never requires the
+`google-cloud-storage` wheel to be installed.
+"""
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+
+def _client(service_account_json: str, project_id: str):
+    from google.cloud import storage
+    from google.oauth2 import service_account
+
+    credentials = service_account.Credentials.from_service_account_info(
+        json.loads(service_account_json)
+    )
+    return storage.Client(project=project_id, credentials=credentials)
+
+
+class GcsStateService:
+    """StateStore backed by a GCS bucket (service-account JSON auth)."""
+
+    def __init__(
+        self,
+        bucket: str,
+        service_account_json: str,
+        project_id: str,
+        prefix: str = "",
+    ):
+        self._bucket = _client(service_account_json, project_id).bucket(bucket)
+        self._prefix = (prefix or "").strip("/")
+
+    def _name(self, key: str) -> str:
+        return f"{self._prefix}/{key}" if self._prefix else key
+
+    def get_state_at(self, key: str) -> Optional[bytes]:
+        from google.cloud.exceptions import NotFound
+
+        blob = self._bucket.blob(self._name(key))
+        try:
+            return blob.download_as_bytes()
+        except NotFound:
+            return None
+
+    def put_state_at(self, key: str, state_bytes: bytes) -> None:
+        # GCS encrypts at rest with Google-managed keys by default.
+        blob = self._bucket.blob(self._name(key))
+        blob.upload_from_string(state_bytes, content_type="application/json")
+
+    def delete_state_at(self, key: str) -> bool:
+        from google.cloud.exceptions import NotFound
+
+        blob = self._bucket.blob(self._name(key))
+        try:
+            blob.delete()
+            return True
+        except NotFound:
+            return True
+
+    # ------------------------------------------------------------------
+    # Admin helpers (used by the gcp-projects router /bucket + /test)
+    # ------------------------------------------------------------------
+    @staticmethod
+    def ensure_bucket(
+        bucket: str,
+        service_account_json: str,
+        project_id: str,
+        region: str = "us-central1",
+    ) -> bool:
+        """Create the bucket (uniform bucket-level access + versioning) if absent.
+        Returns True if it already existed."""
+        from google.cloud.exceptions import Conflict
+
+        client = _client(service_account_json, project_id)
+        bucket_obj = client.bucket(bucket)
+        if bucket_obj.exists():
+            return True
+        bucket_obj.iam_configuration.uniform_bucket_level_access_enabled = True
+        bucket_obj.versioning_enabled = True
+        try:
+            client.create_bucket(bucket_obj, location=region)
+            return False
+        except Conflict:
+            return True
+
+    @staticmethod
+    def verify_bucket(bucket: str, service_account_json: str, project_id: str) -> None:
+        """Raise if the SA cannot access the bucket (used by /test)."""
+        _client(service_account_json, project_id).get_bucket(bucket)

--- a/services/api/app/services/s3_state_service.py
+++ b/services/api/app/services/s3_state_service.py
@@ -4,6 +4,15 @@ from typing import Optional
 
 
 class S3StateService:
+    """AWS S3 (or LocalStack) backend for Terraform state.
+
+    Implements the ``StateStore`` protocol (see ``state_store.py``) via the
+    explicit-key ``get_state_at`` / ``put_state_at`` / ``delete_state_at``
+    methods. The S3-specific ``ServerSideEncryption`` and LocalStack endpoint
+    stay confined here; they are deliberately absent from the ``StateStore``
+    contract so other backends aren't forced to model them.
+    """
+
     def __init__(
         self,
         bucket: str,

--- a/services/api/app/services/state_store.py
+++ b/services/api/app/services/state_store.py
@@ -1,0 +1,35 @@
+"""Backend-neutral Terraform state object store.
+
+The API is the only component that persists Terraform state; the executor
+always talks to the HTTP state backend (`routers/state.py`) and never learns
+which object store sits behind it. This Protocol is the contract every backend
+must satisfy so `state.py`'s HTTP-status mapping stays correct regardless of
+whether state lives in S3, Azure Blob, or GCS.
+"""
+from typing import Optional, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class StateStore(Protocol):
+    """Object-store contract for Terraform state.
+
+    Every implementation MUST honor this so `routers/state.py` keeps its
+    404-vs-503 (GET) and 500 (POST) invariants:
+
+    - ``get_state_at``: return the state bytes, or ``None`` *iff* the object
+      does not exist. Any other failure (auth, network, misconfig) MUST raise
+      — the GET handler maps a raised exception to 503, but ``None`` to a
+      legitimate 404 ("no state yet").
+    - ``delete_state_at``: return ``True`` on a successful delete OR when the
+      object is already absent; raise on anything else.
+    - ``put_state_at``: persist the bytes; raise on failure (→ 500).
+
+    Encryption-at-rest and endpoint/LocalStack handling are backend-internal
+    and MUST NOT appear in this surface.
+    """
+
+    def get_state_at(self, key: str) -> Optional[bytes]: ...
+
+    def put_state_at(self, key: str, state_bytes: bytes) -> None: ...
+
+    def delete_state_at(self, key: str) -> bool: ...

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -18,6 +18,12 @@ dependencies = [
     "bcrypt>=4.0",
     "cryptography",
     "boto3",
+    # Pluggable Terraform state backends (S3 is boto3 above). All pure-Python
+    # / manylinux wheels → no extra system packages in the Dockerfile.
+    "azure-identity>=1.16",
+    "azure-storage-blob>=12.20",
+    "google-cloud-storage>=2.16",
+    "google-auth>=2.30",
     "httpx",
     "docker>=7.0",
     # OIDC / SSO (generic IdP support). Lightweight.

--- a/services/api/requirements.lock
+++ b/services/api/requirements.lock
@@ -62,6 +62,20 @@ authlib==1.7.2 \
     --hash=sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231 \
     --hash=sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f
     # via terraducktel-api
+azure-core==1.41.0 \
+    --hash=sha256:522b4011e8180b1a3dcd2024396a4e7fe9ac37fb8597db47163d230b5efe892d \
+    --hash=sha256:f46ff5dfcd230f25cf1c19e8a34b8dc08a337b2503e268bb600a16c00db8ad5a
+    # via
+    #   azure-identity
+    #   azure-storage-blob
+azure-identity==1.25.3 \
+    --hash=sha256:ab23c0d63015f50b630ef6c6cf395e7262f439ce06e5d07a64e874c724f8d9e6 \
+    --hash=sha256:f4d0b956a8146f30333e071374171f3cfa7bdb8073adb8c3814b65567aa7447c
+    # via terraducktel-api
+azure-storage-blob==12.30.0 \
+    --hash=sha256:2cd74d4d5731e5eb6b8d5c5056ee115a5e88f8fdf22517b739836fda685018be \
+    --hash=sha256:d415ac50b67a8da6b3ae7e9f1014b1b55cd7aafa0b8d4ca9b380568dc7360423
+    # via terraducktel-api
 bcrypt==5.0.0 \
     --hash=sha256:0c418ca99fd47e9c59a301744d63328f17798b5947b0f791e9af3c1c499c2d0a \
     --hash=sha256:0c8e093ea2532601a6f686edbc2c6b2ec24131ff5c52f7610dd64fa4553b5464 \
@@ -403,7 +417,12 @@ cryptography==49.0.0 \
     --hash=sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493
     # via
     #   authlib
+    #   azure-identity
+    #   azure-storage-blob
+    #   google-auth
     #   joserfc
+    #   msal
+    #   pyjwt
     #   python-jose
     #   terraducktel-api
 docker==7.1.0 \
@@ -418,6 +437,56 @@ fastapi==0.139.0 \
     --hash=sha256:99ab7b2d92223c76d6cf10757ab3f89d45b38267fc20b2a136cf02f6beac3145 \
     --hash=sha256:cf15e1e9e667ddb0ad63811e60bd11390d1aac838ca4a7a23f421807b2308189
     # via terraducktel-api
+google-api-core==2.31.0 \
+    --hash=sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2 \
+    --hash=sha256:ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab
+    # via
+    #   google-cloud-core
+    #   google-cloud-storage
+google-auth==2.55.2 \
+    --hash=sha256:97ae7790ff740f2bc9db60eb864a7804f4ac19f5f02c38b3d942f2fea6e9b9ae \
+    --hash=sha256:d715f265f2cafc6a5f1bf0dc19870d20e3119f6f6682785a250bce3d03d38a3b
+    # via
+    #   google-api-core
+    #   google-cloud-core
+    #   google-cloud-storage
+    #   terraducktel-api
+google-cloud-core==2.6.0 \
+    --hash=sha256:6d63ac8e5eca6d9e4319d0a1e2265fadcd7f1049904378caecfa01cf52dd869e \
+    --hash=sha256:e76149739f90fac1fc6757c09f47eaccb3145b54adbd7759b0f7c4b235f46c83
+    # via google-cloud-storage
+google-cloud-storage==3.12.1 \
+    --hash=sha256:1d81491c7663bc26c5056d00b834356f2253b910ef467f9cf9928a87fca1e04b \
+    --hash=sha256:9297ae0c2ce3f5400b1f2bb3a3e6d2cd256614366e03cd30600871df8e903afb
+    # via terraducktel-api
+google-crc32c==1.8.0 \
+    --hash=sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411 \
+    --hash=sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb \
+    --hash=sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa \
+    --hash=sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962 \
+    --hash=sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b \
+    --hash=sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27 \
+    --hash=sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113 \
+    --hash=sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f \
+    --hash=sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8 \
+    --hash=sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21 \
+    --hash=sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79 \
+    --hash=sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2 \
+    --hash=sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454 \
+    --hash=sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2 \
+    --hash=sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697 \
+    --hash=sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651
+    # via
+    #   google-cloud-storage
+    #   google-resumable-media
+google-resumable-media==2.10.0 \
+    --hash=sha256:88152884bee37b2bf36a0ab81ad8c7fd12212c9803dd981d77c1b35b02d34e7c \
+    --hash=sha256:e324bc9d0fdae4c52a08ae90456edc4e71ece858399e1217ac0eb3a51d6bc6ee
+    # via google-cloud-storage
+googleapis-common-protos==1.75.0 \
+    --hash=sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd \
+    --hash=sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed
+    # via google-api-core
 greenlet==3.5.3 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64' \
     --hash=sha256:12a248ba75f6a9a236375f52296c498c89ff1d8badf32deb9eca7abd5853f7da \
     --hash=sha256:1540dd8e5fc2a5aec40fbb98ef8e149fa47c89a4b4a1cf2575a14d3d1869d7a8 \
@@ -536,6 +605,10 @@ iniconfig==2.3.0 \
     --hash=sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730 \
     --hash=sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12
     # via pytest
+isodate==0.7.2 \
+    --hash=sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15 \
+    --hash=sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6
+    # via azure-storage-blob
 itsdangerous==2.2.0 \
     --hash=sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef \
     --hash=sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173
@@ -612,6 +685,16 @@ markupsafe==3.0.3 \
     --hash=sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523 \
     --hash=sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50
     # via mako
+msal==1.37.0 \
+    --hash=sha256:1b1672a33ee467c1d70b341bb16cafd51bb3c817147a95b93263794b03971bec \
+    --hash=sha256:dd17e95a7c71bce75e8108113438ba7c4a086b3bcad4f57a8c09b7af3d753c2d
+    # via
+    #   azure-identity
+    #   msal-extensions
+msal-extensions==1.3.1 \
+    --hash=sha256:96d3de4d034504e969ac5e85bae8106c8373b5c6568e4c8fa7af2eca9dbe6bca \
+    --hash=sha256:c5b0fd10f65ef62b5f1d62f4251d51cbcaf003fcedae8c91b040a488614be1a4
+    # via azure-identity
 packaging==26.2 \
     --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
     --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
@@ -622,6 +705,23 @@ pluggy==1.6.0 \
     # via
     #   pytest
     #   pytest-cov
+proto-plus==1.28.1 \
+    --hash=sha256:6660f5f1970874bdcfc3088b435188a36a37bd3596668f7d726417c4ae8cfbed \
+    --hash=sha256:832e68e7fe064cf90ab153b6e5eb935b27891bb89aaeb68b115e9b702f6cb168
+    # via google-api-core
+protobuf==7.35.1 \
+    --hash=sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799 \
+    --hash=sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87 \
+    --hash=sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6 \
+    --hash=sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30 \
+    --hash=sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9 \
+    --hash=sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4 \
+    --hash=sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4 \
+    --hash=sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a
+    # via
+    #   google-api-core
+    #   googleapis-common-protos
+    #   proto-plus
 psycopg2-binary==2.9.12 \
     --hash=sha256:00814e40fa23c2b37ef0a1e3c749d89982c73a9cb5046137f0752a22d432e82f \
     --hash=sha256:1006fb62f0f0bc5ce256a832356c6262e91be43f5e4eb15b5eaf38079464caf2 \
@@ -662,8 +762,13 @@ pyasn1==0.6.3 \
     --hash=sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf \
     --hash=sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde
     # via
+    #   pyasn1-modules
     #   python-jose
     #   rsa
+pyasn1-modules==0.4.2 \
+    --hash=sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a \
+    --hash=sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6
+    # via google-auth
 pycparser==3.0 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy' \
     --hash=sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29 \
     --hash=sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
@@ -743,6 +848,10 @@ pygments==2.20.0 \
     --hash=sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f \
     --hash=sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176
     # via pytest
+pyjwt==2.13.0 \
+    --hash=sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423 \
+    --hash=sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728
+    # via msal
 pytest==9.1.1 \
     --hash=sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313 \
     --hash=sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c
@@ -828,7 +937,12 @@ pyyaml==6.0.3 \
 requests==2.34.2 \
     --hash=sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0 \
     --hash=sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed
-    # via docker
+    # via
+    #   azure-core
+    #   docker
+    #   google-api-core
+    #   google-cloud-storage
+    #   msal
 rsa==4.9.1 \
     --hash=sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762 \
     --hash=sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75
@@ -887,6 +1001,9 @@ typing-extensions==4.16.0 \
     # via
     #   alembic
     #   anyio
+    #   azure-core
+    #   azure-identity
+    #   azure-storage-blob
     #   fastapi
     #   pydantic
     #   pydantic-core

--- a/services/api/tests/conftest.py
+++ b/services/api/tests/conftest.py
@@ -53,6 +53,7 @@ async def _setup_db():
     import app.models.inventory_ignore_rule  # noqa: F401
     import app.models.aws_account  # noqa: F401
     import app.models.azure_subscription  # noqa: F401
+    import app.models.gcp_project  # noqa: F401
     import app.models.run_step  # noqa: F401
     import app.models.run_job  # noqa: F401
     import app.models.variable  # noqa: F401
@@ -249,6 +250,7 @@ async def db_session():
     import app.models.inventory_ignore_rule  # noqa: F401
     import app.models.aws_account  # noqa: F401
     import app.models.azure_subscription  # noqa: F401
+    import app.models.gcp_project  # noqa: F401
     import app.models.run_step  # noqa: F401
     import app.models.run_job  # noqa: F401
     import app.models.variable  # noqa: F401

--- a/services/api/tests/test_gcp_projects_router.py
+++ b/services/api/tests/test_gcp_projects_router.py
@@ -1,0 +1,134 @@
+"""Router coverage for /api/v1/gcp-projects: CRUD + BU scope + RBAC +
+SA-JSON validation + project-id mismatch + /test + /bucket guards.
+
+google-auth / google-cloud-storage are NOT installed in the test image, so
+the /test and /bucket endpoints exercise their graceful-fallback branches.
+"""
+import json
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("default_bu")
+
+
+def _h(token, bu="default"):
+    return {"Authorization": f"Bearer {token}", "X-Business-Unit": bu}
+
+
+def _sa_json(project_id="acme-prod-1234", email=None):
+    email = email or f"sa@{project_id}.iam.gserviceaccount.com"
+    return json.dumps({
+        "type": "service_account",
+        "project_id": project_id,
+        "private_key_id": "abc123def456",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nMIIfakekey\n-----END PRIVATE KEY-----\n",
+        "client_email": email,
+        "client_id": "123456789",
+        "token_uri": "https://oauth2.googleapis.com/token",
+    })
+
+
+def _body(project_id="acme-prod-1234", **over):
+    b = {
+        "project_id": project_id,
+        "name": f"gcp-{project_id}",
+        "default_region": "us-central1",
+        "service_account_json": _sa_json(project_id=project_id),
+    }
+    b.update(over)
+    return b
+
+
+async def _create(client, token, **over):
+    r = await client.post("/api/v1/gcp-projects", json=_body(**over), headers=_h(token))
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+async def test_crud_and_list(auth_client, admin_token):
+    proj = await _create(auth_client, admin_token)
+    # Masked SA = the client_email (an identifier); the key JSON never leaks.
+    assert proj["service_account_masked"].endswith("gserviceaccount.com")
+    assert "service_account_json" not in proj
+    assert "service_account_json_encrypted" not in proj
+    lst = await auth_client.get("/api/v1/gcp-projects", headers=_h(admin_token))
+    assert any(p["id"] == proj["id"] for p in lst.json())
+    upd = await auth_client.put(
+        f"/api/v1/gcp-projects/{proj['id']}",
+        json={"name": "renamed", "state_bucket": "acme-tfstate"},
+        headers=_h(admin_token),
+    )
+    assert upd.status_code == 200
+    assert upd.json()["name"] == "renamed"
+    assert upd.json()["state_bucket"] == "acme-tfstate"
+    d = await auth_client.delete(f"/api/v1/gcp-projects/{proj['id']}", headers=_h(admin_token))
+    assert d.status_code == 204
+
+
+async def test_duplicate_409_and_404s(auth_client, admin_token):
+    await _create(auth_client, admin_token, project_id="dup-proj-9999")
+    dup = await auth_client.post(
+        "/api/v1/gcp-projects", json=_body(project_id="dup-proj-9999"), headers=_h(admin_token)
+    )
+    assert dup.status_code == 409
+    assert (
+        await auth_client.put("/api/v1/gcp-projects/x", json={"name": "n"}, headers=_h(admin_token))
+    ).status_code == 404
+    assert (
+        await auth_client.delete("/api/v1/gcp-projects/x", headers=_h(admin_token))
+    ).status_code == 404
+
+
+async def test_sa_json_must_be_valid(auth_client, admin_token):
+    r = await auth_client.post(
+        "/api/v1/gcp-projects", json=_body(service_account_json="not json"), headers=_h(admin_token)
+    )
+    assert r.status_code == 422
+    bad = json.dumps({"type": "user", "project_id": "acme-prod-1234", "client_email": "x", "private_key": "y"})
+    r = await auth_client.post(
+        "/api/v1/gcp-projects", json=_body(service_account_json=bad), headers=_h(admin_token)
+    )
+    assert r.status_code == 422
+
+
+async def test_project_id_mismatch_422(auth_client, admin_token):
+    body = _body(project_id="declared-proj-1")
+    body["service_account_json"] = _sa_json(project_id="other-proj-2")
+    r = await auth_client.post("/api/v1/gcp-projects", json=body, headers=_h(admin_token))
+    assert r.status_code == 422
+    assert "other-proj-2" in r.text
+
+
+async def test_rbac_viewer_cannot_create(auth_client, viewer_token):
+    r = await auth_client.post("/api/v1/gcp-projects", json=_body(), headers=_h(viewer_token))
+    assert r.status_code == 403
+
+
+async def test_create_requires_concrete_bu(auth_client, admin_token, _setup_db):
+    from app.models.user import User
+    from sqlalchemy import select
+
+    async with _setup_db() as s:
+        u = (await s.execute(select(User).where(User.email == "admin@test.com"))).scalars().first()
+        u.is_superadmin = True
+        await s.commit()
+    r = await auth_client.post("/api/v1/gcp-projects", json=_body(), headers=_h(admin_token, bu="all"))
+    assert r.status_code == 400
+
+
+async def test_test_connection_invalid_key(auth_client, admin_token):
+    # The stored SA key is structurally valid JSON but has a fake private_key,
+    # so minting a token fails → ok=False (never raises). Covers the real
+    # path when google-auth IS installed (as it is in the API image).
+    proj = await _create(auth_client, admin_token, project_id="test-proj-5555")
+    r = await auth_client.post(f"/api/v1/gcp-projects/{proj['id']}/test", headers=_h(admin_token))
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is False
+    assert body["detail"]  # some validation error message is surfaced
+
+
+async def test_bucket_requires_state_bucket(auth_client, admin_token):
+    proj = await _create(auth_client, admin_token, project_id="nobucket-8888")
+    r = await auth_client.post(f"/api/v1/gcp-projects/{proj['id']}/bucket", headers=_h(admin_token))
+    assert r.status_code == 400

--- a/services/api/tests/test_state_backends.py
+++ b/services/api/tests/test_state_backends.py
@@ -1,0 +1,175 @@
+"""Unit tests for the pluggable StateStore backends (Azure Blob + GCS).
+
+Assert the StateStore contract that routers/state.py depends on:
+  - get_state_at: bytes when present, None when absent, RAISES on other errors
+  - delete_state_at: True on delete-or-already-absent, RAISES on other errors
+  - put_state_at: persists bytes; no SSE-specific coupling
+
+Real cloud clients are replaced with in-memory fakes via the module-level
+`_blob_service` / `_client` factory functions.
+"""
+import pytest
+
+from azure.core.exceptions import ResourceNotFoundError
+from google.cloud.exceptions import NotFound
+
+from app.services import azure_blob_state_service as az
+from app.services import gcs_state_service as gcs
+from app.services.state_store import StateStore
+
+
+# --------------------------------------------------------------------------
+# Azure Blob
+# --------------------------------------------------------------------------
+class _FakeAzureBlob:
+    def __init__(self, store, key):
+        self._store, self._key = store, key
+
+    def download_blob(self):
+        if self._key not in self._store:
+            raise ResourceNotFoundError("nope")
+        data = self._store[self._key]
+
+        class _D:
+            def readall(_self):
+                return data
+
+        return _D()
+
+    def upload_blob(self, data, overwrite=False):
+        self._store[self._key] = data
+
+    def delete_blob(self):
+        if self._key not in self._store:
+            raise ResourceNotFoundError("nope")
+        del self._store[self._key]
+
+
+class _FakeAzureService:
+    def __init__(self, store):
+        self._store = store
+
+    def get_blob_client(self, container, key):
+        return _FakeAzureBlob(self._store, key)
+
+
+@pytest.fixture
+def azure_store(monkeypatch):
+    backing: dict[str, bytes] = {}
+    monkeypatch.setattr(az, "_blob_service", lambda *a, **k: _FakeAzureService(backing))
+    return az.AzureBlobStateService("acct", "cont", "t", "c", "s"), backing
+
+
+def test_azure_implements_protocol(azure_store):
+    svc, _ = azure_store
+    assert isinstance(svc, StateStore)
+
+
+def test_azure_roundtrip(azure_store):
+    svc, _ = azure_store
+    assert svc.get_state_at("k/terraform.tfstate") is None            # absent → None (→ 404)
+    svc.put_state_at("k/terraform.tfstate", b'{"v":1}')
+    assert svc.get_state_at("k/terraform.tfstate") == b'{"v":1}'
+    assert svc.delete_state_at("k/terraform.tfstate") is True
+    assert svc.delete_state_at("k/terraform.tfstate") is True         # already-absent → True
+    assert svc.get_state_at("k/terraform.tfstate") is None
+
+
+def test_azure_get_reraises_unknown(monkeypatch):
+    class _BoomBlob:
+        def download_blob(self):
+            raise ValueError("network")
+
+    class _BoomSvc:
+        def get_blob_client(self, c, k):
+            return _BoomBlob()
+
+    monkeypatch.setattr(az, "_blob_service", lambda *a, **k: _BoomSvc())
+    svc = az.AzureBlobStateService("a", "b", "t", "c", "s")
+    with pytest.raises(ValueError):  # non-not-found errors must surface (→ 503)
+        svc.get_state_at("k")
+
+
+# --------------------------------------------------------------------------
+# GCS
+# --------------------------------------------------------------------------
+class _FakeGcsBlob:
+    def __init__(self, store, name):
+        self._store, self._name = store, name
+
+    def download_as_bytes(self):
+        if self._name not in self._store:
+            raise NotFound("nope")
+        return self._store[self._name]
+
+    def upload_from_string(self, data, content_type=None):
+        self._store[self._name] = data if isinstance(data, bytes) else data.encode()
+
+    def delete(self):
+        if self._name not in self._store:
+            raise NotFound("nope")
+        del self._store[self._name]
+
+
+class _FakeGcsBucket:
+    def __init__(self, store):
+        self._store = store
+
+    def blob(self, name):
+        return _FakeGcsBlob(self._store, name)
+
+
+class _FakeGcsClient:
+    def __init__(self, store):
+        self._store = store
+
+    def bucket(self, name):
+        return _FakeGcsBucket(self._store)
+
+
+@pytest.fixture
+def gcs_store(monkeypatch):
+    backing: dict[str, bytes] = {}
+    monkeypatch.setattr(gcs, "_client", lambda *a, **k: _FakeGcsClient(backing))
+    return gcs.GcsStateService("bkt", "{}", "proj", prefix=""), backing
+
+
+def test_gcs_implements_protocol(gcs_store):
+    svc, _ = gcs_store
+    assert isinstance(svc, StateStore)
+
+
+def test_gcs_roundtrip(gcs_store):
+    svc, _ = gcs_store
+    assert svc.get_state_at("k/terraform.tfstate") is None
+    svc.put_state_at("k/terraform.tfstate", b'{"v":2}')
+    assert svc.get_state_at("k/terraform.tfstate") == b'{"v":2}'
+    assert svc.delete_state_at("k/terraform.tfstate") is True
+    assert svc.delete_state_at("k/terraform.tfstate") is True
+
+
+def test_gcs_prefix_applied(monkeypatch):
+    backing: dict[str, bytes] = {}
+    monkeypatch.setattr(gcs, "_client", lambda *a, **k: _FakeGcsClient(backing))
+    svc = gcs.GcsStateService("bkt", "{}", "proj", prefix="team-a/")
+    svc.put_state_at("k/terraform.tfstate", b"x")
+    assert "team-a/k/terraform.tfstate" in backing
+
+
+def test_gcs_get_reraises_unknown(monkeypatch):
+    class _BoomBlob:
+        def download_as_bytes(self):
+            raise ValueError("network")
+
+    class _BoomBucket:
+        def blob(self, n):
+            return _BoomBlob()
+
+    class _BoomClient:
+        def bucket(self, n):
+            return _BoomBucket()
+
+    monkeypatch.setattr(gcs, "_client", lambda *a, **k: _BoomClient())
+    svc = gcs.GcsStateService("b", "{}", "p")
+    with pytest.raises(ValueError):
+        svc.get_state_at("k")

--- a/services/api/tests/test_workspace_state_backend.py
+++ b/services/api/tests/test_workspace_state_backend.py
@@ -1,0 +1,159 @@
+"""state_backend validation on workspace create/update.
+
+Exercises routers/workspaces.py `_validate_state_backend_linkage`: a workspace
+may only select azureblob/gcs when the matching cloud link + storage target
+are present. Also covers the schema-level rejection of unknown backends and
+the happy paths.
+"""
+import json
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("default_bu")
+
+
+def _h(token, bu="default"):
+    return {"Authorization": f"Bearer {token}", "X-Business-Unit": bu}
+
+
+def _sa_json(project_id):
+    return json.dumps({
+        "type": "service_account",
+        "project_id": project_id,
+        "private_key_id": "k1",
+        "private_key": "-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----\n",
+        "client_email": f"sa@{project_id}.iam.gserviceaccount.com",
+        "client_id": "1",
+        "token_uri": "https://oauth2.googleapis.com/token",
+    })
+
+
+async def _mk_azure_sub(client, token, *, with_storage):
+    body = {
+        "subscription_id": "00000000-0000-0000-0000-000000000abc",
+        "tenant_id": "11111111-1111-1111-1111-111111111111",
+        "client_id": "22222222-2222-2222-2222-222222222222",
+        "client_secret": "sp-secret",
+        "name": "azure-state",
+    }
+    if with_storage:
+        body["state_storage_account"] = "acmetfstate"
+        body["state_container"] = "tfstate"
+    r = await client.post("/api/v1/azure-subscriptions", json=body, headers=_h(token))
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+async def _mk_gcp_project(client, token, project_id, *, with_bucket):
+    body = {
+        "project_id": project_id,
+        "name": project_id,
+        "service_account_json": _sa_json(project_id),
+    }
+    if with_bucket:
+        body["state_bucket"] = f"{project_id}-tfstate"
+    r = await client.post("/api/v1/gcp-projects", json=body, headers=_h(token))
+    assert r.status_code == 201, r.text
+    return r.json()["id"]
+
+
+def _ws_body(default_aws_account, **over):
+    b = {
+        "name": "ws",
+        "environment": "dev",
+        "aws_account_id": default_aws_account,
+        "region": "us-east-1",
+        "tf_working_dir": "envs/x",
+    }
+    b.update(over)
+    return b
+
+
+async def test_invalid_state_backend_value_422(auth_client, admin_token, default_aws_account):
+    r = await auth_client.post(
+        "/api/v1/workspaces",
+        json=_ws_body(default_aws_account, name="ws-bad", tf_working_dir="envs/bad", state_backend="swift"),
+        headers=_h(admin_token),
+    )
+    assert r.status_code == 422
+
+
+async def test_azureblob_requires_configured_sub(auth_client, admin_token, default_aws_account):
+    # azureblob with no azure link at all → 422
+    r = await auth_client.post(
+        "/api/v1/workspaces",
+        json=_ws_body(default_aws_account, name="ws-az0", tf_working_dir="envs/az0", state_backend="azureblob"),
+        headers=_h(admin_token),
+    )
+    assert r.status_code == 422
+    assert "azureblob" in r.json()["detail"]
+
+    # linked sub exists but has NO storage container → still 422
+    sub_id = await _mk_azure_sub(auth_client, admin_token, with_storage=False)
+    r = await auth_client.post(
+        "/api/v1/workspaces",
+        json=_ws_body(
+            default_aws_account, name="ws-az1", tf_working_dir="envs/az1",
+            azure_subscription_id=sub_id, state_backend="azureblob",
+        ),
+        headers=_h(admin_token),
+    )
+    assert r.status_code == 422
+
+
+async def test_azureblob_happy_path(auth_client, admin_token, default_aws_account):
+    sub_id = await _mk_azure_sub(auth_client, admin_token, with_storage=True)
+    r = await auth_client.post(
+        "/api/v1/workspaces",
+        json=_ws_body(
+            default_aws_account, name="ws-azok", tf_working_dir="envs/azok",
+            azure_subscription_id=sub_id, state_backend="azureblob",
+        ),
+        headers=_h(admin_token),
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["state_backend"] == "azureblob"
+
+
+async def test_gcs_requires_bucket(auth_client, admin_token, default_aws_account):
+    # gcs with no gcp link → 422
+    r = await auth_client.post(
+        "/api/v1/workspaces",
+        json=_ws_body(default_aws_account, name="ws-gcs0", tf_working_dir="envs/gcs0", state_backend="gcs"),
+        headers=_h(admin_token),
+    )
+    assert r.status_code == 422
+
+    # project WITHOUT a bucket → 422
+    proj = await _mk_gcp_project(auth_client, admin_token, "gcsproj-nobkt", with_bucket=False)
+    r = await auth_client.post(
+        "/api/v1/workspaces",
+        json=_ws_body(
+            default_aws_account, name="ws-gcs1", tf_working_dir="envs/gcs1",
+            gcp_project_id=proj, state_backend="gcs",
+        ),
+        headers=_h(admin_token),
+    )
+    assert r.status_code == 422
+
+
+async def test_gcs_update_path_happy(auth_client, admin_token, default_aws_account):
+    proj = await _mk_gcp_project(auth_client, admin_token, "gcsproj-ok", with_bucket=True)
+    created = await auth_client.post(
+        "/api/v1/workspaces",
+        json=_ws_body(default_aws_account, name="ws-up", tf_working_dir="envs/up"),
+        headers=_h(admin_token),
+    )
+    assert created.status_code == 201, created.text
+    assert created.json()["state_backend"] == "s3"
+    ws_id = created.json()["id"]
+
+    # Flip to gcs + link project in the same call → effective-linkage check passes.
+    upd = await auth_client.put(
+        f"/api/v1/workspaces/{ws_id}",
+        json={"state_backend": "gcs", "gcp_project_id": proj},
+        headers=_h(admin_token),
+    )
+    assert upd.status_code == 200, upd.text
+    assert upd.json()["state_backend"] == "gcs"
+    assert upd.json()["gcp_project_id"] == proj

--- a/services/api/uv.lock
+++ b/services/api/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 2
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version < '3.13'",
+]
 
 [[package]]
 name = "aiosqlite"
@@ -107,6 +111,50 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
+]
+
+[[package]]
+name = "azure-core"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/f3/b416179e408990df5db0d516283022dde0f5d0111d98c1a848e41853e81c/azure_core-1.41.0.tar.gz", hash = "sha256:f46ff5dfcd230f25cf1c19e8a34b8dc08a337b2503e268bb600a16c00db8ad5a", size = 381042, upload-time = "2026-05-07T23:30:54.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/db/325c6d7312d2200251c52323878281045aaffcb5586612296484e4280eaa/azure_core-1.41.0-py3-none-any.whl", hash = "sha256:522b4011e8180b1a3dcd2024396a4e7fe9ac37fb8597db47163d230b5efe892d", size = 220920, upload-time = "2026-05-07T23:30:56.357Z" },
+]
+
+[[package]]
+name = "azure-identity"
+version = "1.25.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "msal" },
+    { name = "msal-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/0e/3a63efb48aa4a5ae2cfca61ee152fbcb668092134d3eb8bfda472dd5c617/azure_identity-1.25.3.tar.gz", hash = "sha256:ab23c0d63015f50b630ef6c6cf395e7262f439ce06e5d07a64e874c724f8d9e6", size = 286304, upload-time = "2026-03-13T01:12:20.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/9a/417b3a533e01953a7c618884df2cb05a71e7b68bdbce4fbdb62349d2a2e8/azure_identity-1.25.3-py3-none-any.whl", hash = "sha256:f4d0b956a8146f30333e071374171f3cfa7bdb8073adb8c3814b65567aa7447c", size = 192138, upload-time = "2026-03-13T01:12:22.951Z" },
+]
+
+[[package]]
+name = "azure-storage-blob"
+version = "12.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/48/84a820d898267f662b5c06f7cd76fdb8a9e272b44aa9376cef3ec0f6a294/azure_storage_blob-12.30.0.tar.gz", hash = "sha256:2cd74d4d5731e5eb6b8d5c5056ee115a5e88f8fdf22517b739836fda685018be", size = 618229, upload-time = "2026-06-08T11:45:35.575Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/0b/e106f0fd7fa785867d9ffcc47dc9e6237c0e58f51058473b777487a98edc/azure_storage_blob-12.30.0-py3-none-any.whl", hash = "sha256:d415ac50b67a8da6b3ae7e9f1014b1b55cd7aafa0b8d4ca9b380568dc7360423", size = 435610, upload-time = "2026-06-08T11:45:37.213Z" },
 ]
 
 [[package]]
@@ -553,6 +601,112 @@ wheels = [
 ]
 
 [[package]]
+name = "google-api-core"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/22/155cadf1d49272a9cf48f3168c0f3874fa13397297e611a5ea00cd093880/google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2", size = 176492, upload-time = "2026-06-03T14:52:17.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/40/9bdbb60b03a332bd45acb8703da08bbc27d991d35286b62e42acc86d243a/google_api_core-2.31.0-py3-none-any.whl", hash = "sha256:ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab", size = 173102, upload-time = "2026-06-03T14:51:26.729Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.55.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/b9/e370d86fea3da13ec0256df30323dd26c0cb9c8c85f0c6ec42ac9df0106b/google_auth-2.55.2.tar.gz", hash = "sha256:97ae7790ff740f2bc9db60eb864a7804f4ac19f5f02c38b3d942f2fea6e9b9ae", size = 361414, upload-time = "2026-07-07T18:43:21.227Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/c6/02eb5a337ac316a4c30c012e747bad5cea36e1a876efecdf80865541f7d8/google_auth-2.55.2-py3-none-any.whl", hash = "sha256:d715f265f2cafc6a5f1bf0dc19870d20e3119f6f6682785a250bce3d03d38a3b", size = 256778, upload-time = "2026-07-07T18:43:19.52Z" },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/dd/1eef226e470369b26824a505c34482c0b493bc35fe8e0c6b003b5feca21a/google_cloud_core-2.6.0.tar.gz", hash = "sha256:e76149739f90fac1fc6757c09f47eaccb3145b54adbd7759b0f7c4b235f46c83", size = 36001, upload-time = "2026-05-07T08:04:04.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/4a/98da8930ab109c73d9a5d13782a9ebb81ea8c111f6d534a567b71d23e52b/google_cloud_core-2.6.0-py3-none-any.whl", hash = "sha256:6d63ac8e5eca6d9e4319d0a1e2265fadcd7f1049904378caecfa01cf52dd869e", size = 29390, upload-time = "2026-05-07T08:02:34.672Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "3.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/ac/60b4cb0a6c8c6bb7cedb8971ba5e34a94096acf76e2cc242bcf1e6fc5c49/google_cloud_storage-3.12.1.tar.gz", hash = "sha256:1d81491c7663bc26c5056d00b834356f2253b910ef467f9cf9928a87fca1e04b", size = 17339353, upload-time = "2026-07-08T17:03:59.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/ca176e95bafac0fe7befeee7e0420e686de147571cd2908e308c5fe71bda/google_cloud_storage-3.12.1-py3-none-any.whl", hash = "sha256:9297ae0c2ce3f5400b1f2bb3a3e6d2cd256614366e03cd30600871df8e903afb", size = 340845, upload-time = "2026-07-08T17:03:31.418Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/f8/1ca5781d6be9cb9f73f7d40f4958c4bd1226a60598e3e39e1d6aaf838c4b/google_resumable_media-2.10.0.tar.gz", hash = "sha256:e324bc9d0fdae4c52a08ae90456edc4e71ece858399e1217ac0eb3a51d6bc6ee", size = 2164570, upload-time = "2026-06-03T16:14:26.103Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/d8/00c6854ac1512bb9eaf13bd3f8f28222f7674947fc510a4ff7616f2efc80/google_resumable_media-2.10.0-py3-none-any.whl", hash = "sha256:88152884bee37b2bf36a0ab81ad8c7fd12212c9803dd981d77c1b35b02d34e7c", size = 81533, upload-time = "2026-06-03T16:13:12.51Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.5.3"
 source = { registry = "https://pypi.org/simple" }
@@ -711,6 +865,15 @@ wheels = [
 ]
 
 [[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -816,6 +979,32 @@ wheels = [
 ]
 
 [[package]]
+name = "msal"
+version = "1.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/99/d840198ecf6e8057bbc937f129ae940404485d736cda73253bbff9537f01/msal-1.37.0.tar.gz", hash = "sha256:1b1672a33ee467c1d70b341bb16cafd51bb3c817147a95b93263794b03971bec", size = 182444, upload-time = "2026-05-29T19:49:05.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/b0/d807279f4b55d16d1f120d5ac4344c6e39b56732e2a224d40bded7fd67ad/msal-1.37.0-py3-none-any.whl", hash = "sha256:dd17e95a7c71bce75e8108113438ba7c4a086b3bcad4f57a8c09b7af3d753c2d", size = 123725, upload-time = "2026-05-29T19:49:04.335Z" },
+]
+
+[[package]]
+name = "msal-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/99/5d239b6156eddf761a636bded1118414d161bd6b7b37a9335549ed159396/msal_extensions-1.3.1.tar.gz", hash = "sha256:c5b0fd10f65ef62b5f1d62f4251d51cbcaf003fcedae8c91b040a488614be1a4", size = 23315, upload-time = "2025-03-14T23:51:03.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/75/bd9b7bb966668920f06b200e84454c8f3566b102183bc55c5473d96cb2b9/msal_extensions-1.3.1-py3-none-any.whl", hash = "sha256:96d3de4d034504e969ac5e85bae8106c8373b5c6568e4c8fa7af2eca9dbe6bca", size = 20583, upload-time = "2025-03-14T23:51:03.016Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -831,6 +1020,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "proto-plus"
+version = "1.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/44/767757fd2cdd4a60d7e4440d9f7b491d6131103d313638d2c03e06c268fb/proto_plus-1.28.1.tar.gz", hash = "sha256:832e68e7fe064cf90ab153b6e5eb935b27891bb89aaeb68b115e9b702f6cb168", size = 57166, upload-time = "2026-07-08T17:04:02.367Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/34/2f2b57dbfd145b995a29847a16b0903fce5ef6ad3c7aad740a609c5d3678/proto_plus-1.28.1-py3-none-any.whl", hash = "sha256:6660f5f1970874bdcfc3088b435188a36a37bd3596668f7d726417c4ae8cfbed", size = 50408, upload-time = "2026-07-08T17:03:34.532Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
 ]
 
 [[package]]
@@ -881,6 +1097,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -989,6 +1217,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -1249,11 +1491,15 @@ dependencies = [
     { name = "alembic" },
     { name = "asyncpg" },
     { name = "authlib" },
+    { name = "azure-identity" },
+    { name = "azure-storage-blob" },
     { name = "bcrypt" },
     { name = "boto3" },
     { name = "cryptography" },
     { name = "docker" },
     { name = "fastapi" },
+    { name = "google-auth" },
+    { name = "google-cloud-storage" },
     { name = "httpx" },
     { name = "itsdangerous" },
     { name = "psycopg2-binary" },
@@ -1277,11 +1523,15 @@ requires-dist = [
     { name = "alembic" },
     { name = "asyncpg" },
     { name = "authlib", specifier = ">=1.3" },
+    { name = "azure-identity", specifier = ">=1.16" },
+    { name = "azure-storage-blob", specifier = ">=12.20" },
     { name = "bcrypt", specifier = ">=4.0" },
     { name = "boto3" },
     { name = "cryptography" },
     { name = "docker", specifier = ">=7.0" },
     { name = "fastapi", specifier = ">=0.111" },
+    { name = "google-auth", specifier = ">=2.30" },
+    { name = "google-cloud-storage", specifier = ">=2.16" },
     { name = "httpx" },
     { name = "httpx", marker = "extra == 'dev'" },
     { name = "itsdangerous", specifier = ">=2.2" },

--- a/services/executor/entrypoint.sh
+++ b/services/executor/entrypoint.sh
@@ -53,6 +53,15 @@ export GIT_TERMINAL_PROMPT="0"
 : "${ARM_CLIENT_SECRET:=}"
 : "${TDT_CLOUD_PROVIDERS:=}"
 
+# GCP creds are also SOFT defaults — only populated when the workspace is
+# linked to a gcp_projects row. We write GCP_SA_KEY_JSON to a 0600 file and
+# export GOOGLE_APPLICATION_CREDENTIALS below; the terraform google provider
+# reads GOOGLE_APPLICATION_CREDENTIALS / GOOGLE_PROJECT / GOOGLE_REGION
+# directly (no `gcloud auth`).
+: "${GCP_SA_KEY_JSON:=}"
+: "${GOOGLE_PROJECT:=}"
+: "${GOOGLE_REGION:=}"
+
 # ---------------------------------------------------------------------------
 # report_status: PATCH the run-level status (running/planned/applied/failed).
 # ---------------------------------------------------------------------------
@@ -429,6 +438,20 @@ fi
 if [[ -n "${ARM_CLIENT_ID}" ]]; then
   # Tail-only echo so secrets stay out of logs.
   echo "=== Azure SP auth wired: tenant ${ARM_TENANT_ID:0:8}… subscription ${ARM_SUBSCRIPTION_ID:0:8}… ==="
+fi
+
+# If the workspace is linked to a GCP project, write the service-account key
+# JSON to a 0600 file and point the google provider at it (mirrors the AWS/
+# kubeconfig file-write pattern). Never `gcloud auth` — the provider reads
+# GOOGLE_APPLICATION_CREDENTIALS / GOOGLE_PROJECT / GOOGLE_REGION directly.
+if [[ -n "${GCP_SA_KEY_JSON}" ]]; then
+  mkdir -p ~/.gcp
+  printf '%s' "${GCP_SA_KEY_JSON}" > ~/.gcp/sa-key.json
+  chmod 600 ~/.gcp/sa-key.json
+  export GOOGLE_APPLICATION_CREDENTIALS="${HOME}/.gcp/sa-key.json"
+  export GOOGLE_CLOUD_PROJECT="${GOOGLE_PROJECT}"
+  # Tail-only echo — never print the key JSON.
+  echo "=== GCP SA auth wired: project ${GOOGLE_PROJECT:-<none>} (key at ${GOOGLE_APPLICATION_CREDENTIALS}) ==="
 fi
 
 report_status "running"

--- a/services/ui/src/App.tsx
+++ b/services/ui/src/App.tsx
@@ -308,6 +308,7 @@ function AuthedApp() {
                 <Route path="/users" element={<RequireAuth><Users /></RequireAuth>} />
                 <Route path="/business-units" element={<RequireAuth><BusinessUnits /></RequireAuth>} />
                 <Route path="/clusters" element={<Navigate to="/settings#cloud" replace />} />
+                <Route path="/gcp" element={<Navigate to="/settings#cloud" replace />} />
                 <Route path="/settings" element={<RequireAuth><Settings /></RequireAuth>} />
               </Routes>
             </div>

--- a/services/ui/src/components/WorkspaceTree.tsx
+++ b/services/ui/src/components/WorkspaceTree.tsx
@@ -4,31 +4,34 @@
 // public entry point and orchestrates grouping.
 import { useMemo, useState } from "react";
 import { Card, Input } from "./ui";
-import { AccountGroup, AzureSubscriptionGroup } from "./workspace-tree/groups";
-import { azureInfo, workspacePathSegments } from "./workspace-tree/paths";
+import { AccountGroup, AzureSubscriptionGroup, GcpProjectGroup } from "./workspace-tree/groups";
+import { azureInfo, gcpInfo, workspacePathSegments } from "./workspace-tree/paths";
 import type {
   AwsAccountLite,
   AzureSubscriptionLite,
   ExpandSignal,
+  GcpProjectLite,
   Run,
   Workspace,
 } from "./workspace-tree/types";
 
 // Public surface preserved for existing importers (Dashboard, Settings).
-export type { AwsAccountLite, AzureSubscriptionLite, Run, Workspace };
-export { azureInfo, workspacePathSegments };
+export type { AwsAccountLite, AzureSubscriptionLite, GcpProjectLite, Run, Workspace };
+export { azureInfo, gcpInfo, workspacePathSegments };
 
 export default function WorkspaceTree({
   workspaces,
   runs,
   awsAccounts,
   azureSubscriptions,
+  gcpProjects,
   onChanged,
 }: {
   workspaces: Workspace[];
   runs: Run[];
   awsAccounts: AwsAccountLite[];
   azureSubscriptions: AzureSubscriptionLite[];
+  gcpProjects: GcpProjectLite[];
   onChanged: () => void;
 }) {
   const [filter, setFilter] = useState("");
@@ -55,10 +58,24 @@ export default function WorkspaceTree({
     return m;
   }, [azureSubscriptions]);
 
+  // Same two views for GCP projects: by TDT pk (the explicit link) and by GCP
+  // project id (what the `gcp/project-<id>/` repo path encodes).
+  const gcpByPk = useMemo(() => {
+    const m = new Map<string, GcpProjectLite>();
+    for (const p of gcpProjects) m.set(p.id, p);
+    return m;
+  }, [gcpProjects]);
+  const gcpByProjectId = useMemo(() => {
+    const m = new Map<string, GcpProjectLite>();
+    for (const p of gcpProjects) m.set(p.project_id, p);
+    return m;
+  }, [gcpProjects]);
+
   // Classify a workspace into its top-level cloud group + the region it should
-  // nest under. Azure detection: explicit link first, then the path convention.
+  // nest under. Detection: explicit link first (Azure, then GCP), then the
+  // path convention (Azure, then GCP); AWS is the default.
   function classify(w: Workspace): {
-    cloud: "aws" | "azure";
+    cloud: "aws" | "azure" | "gcp";
     key: string;
     region: string;
   } {
@@ -72,10 +89,24 @@ export default function WorkspaceTree({
         region: info?.region ?? w.region,
       };
     }
+    if (w.gcp_project_id) {
+      const proj = gcpByPk.get(w.gcp_project_id);
+      const info = gcpInfo(w);
+      return {
+        cloud: "gcp",
+        key: proj ? proj.id : w.gcp_project_id,
+        region: info?.region ?? w.region,
+      };
+    }
     const info = azureInfo(w);
     if (info) {
       const sub = azureByGuid.get(info.guid);
       return { cloud: "azure", key: sub ? sub.id : `guid:${info.guid}`, region: info.region };
+    }
+    const ginfo = gcpInfo(w);
+    if (ginfo) {
+      const proj = gcpByProjectId.get(ginfo.projectId);
+      return { cloud: "gcp", key: proj ? proj.id : `pid:${ginfo.projectId}`, region: ginfo.region };
     }
     return { cloud: "aws", key: w.aws_account_id, region: w.region };
   }
@@ -111,6 +142,9 @@ export default function WorkspaceTree({
       const sub = w.azure_subscription_id
         ? azureByPk.get(w.azure_subscription_id)
         : azureByGuid.get(azureInfo(w)?.guid ?? "");
+      const proj = w.gcp_project_id
+        ? gcpByPk.get(w.gcp_project_id)
+        : gcpByProjectId.get(gcpInfo(w)?.projectId ?? "");
       return [
         w.name,
         w.aws_account_id,
@@ -120,32 +154,36 @@ export default function WorkspaceTree({
         accountNameById.get(w.aws_account_id) ?? "",
         sub?.name ?? "",
         sub?.subscription_id ?? azureInfo(w)?.guid ?? "",
+        proj?.name ?? "",
+        proj?.project_id ?? gcpInfo(w)?.projectId ?? "",
       ]
         .join(" ")
         .toLowerCase()
         .includes(q);
     });
-  }, [workspaces, filter, accountNameById, azureByPk, azureByGuid]);
+  }, [workspaces, filter, accountNameById, azureByPk, azureByGuid, gcpByPk, gcpByProjectId]);
 
-  // Group into AWS accounts and Azure subscriptions, each → region → workspaces[].
-  const { awsGrouped, azureGrouped } = useMemo(() => {
+  // Group into AWS accounts, Azure subscriptions, and GCP projects; each →
+  // region → workspaces[].
+  const { awsGrouped, azureGrouped, gcpGrouped } = useMemo(() => {
     const aws: Record<string, Record<string, Workspace[]>> = {};
     const azure: Record<string, Record<string, Workspace[]>> = {};
+    const gcp: Record<string, Record<string, Workspace[]>> = {};
     for (const w of filtered) {
       const c = classify(w);
-      const bucket = c.cloud === "azure" ? azure : aws;
+      const bucket = c.cloud === "azure" ? azure : c.cloud === "gcp" ? gcp : aws;
       const g = (bucket[c.key] ??= {});
       (g[c.region] ??= []).push(w);
     }
-    for (const bucket of [aws, azure]) {
+    for (const bucket of [aws, azure, gcp]) {
       for (const g of Object.values(bucket)) {
         for (const region of Object.keys(g)) g[region].sort((a, b) => a.name.localeCompare(b.name));
       }
     }
-    return { awsGrouped: aws, azureGrouped: azure };
-    // classify closes over the azure lookup maps, which are themselves memoized.
+    return { awsGrouped: aws, azureGrouped: azure, gcpGrouped: gcp };
+    // classify closes over the cloud lookup maps, which are themselves memoized.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filtered, azureByPk, azureByGuid]);
+  }, [filtered, azureByPk, azureByGuid, gcpByPk, gcpByProjectId]);
 
   const accountIds = Object.keys(awsGrouped).sort();
   // Azure groups sorted by display name (registered) then bare GUID key.
@@ -154,7 +192,13 @@ export default function WorkspaceTree({
     const nb = azureByPk.get(b)?.name ?? b;
     return na.localeCompare(nb);
   });
-  const groupCount = accountIds.length + azureKeys.length;
+  // GCP groups sorted by display name (registered) then bare project-id key.
+  const gcpKeys = Object.keys(gcpGrouped).sort((a, b) => {
+    const na = gcpByPk.get(a)?.name ?? a;
+    const nb = gcpByPk.get(b)?.name ?? b;
+    return na.localeCompare(nb);
+  });
+  const groupCount = accountIds.length + azureKeys.length + gcpKeys.length;
 
   return (
     <div className="space-y-4">
@@ -217,6 +261,7 @@ export default function WorkspaceTree({
               expandSignal={expandSignal}
               awsAccounts={awsAccounts}
               azureSubscriptions={azureSubscriptions}
+              gcpProjects={gcpProjects}
             />
           ))}
           {azureKeys.map((key) => (
@@ -231,6 +276,22 @@ export default function WorkspaceTree({
               expandSignal={expandSignal}
               awsAccounts={awsAccounts}
               azureSubscriptions={azureSubscriptions}
+              gcpProjects={gcpProjects}
+            />
+          ))}
+          {gcpKeys.map((key) => (
+            <GcpProjectGroup
+              key={`gcp:${key}`}
+              proj={gcpByPk.get(key)}
+              projectId={key.startsWith("pid:") ? key.slice("pid:".length) : undefined}
+              byRegion={gcpGrouped[key]}
+              latestByWs={latestByWs}
+              defaultOpen={false}
+              onChanged={onChanged}
+              expandSignal={expandSignal}
+              awsAccounts={awsAccounts}
+              azureSubscriptions={azureSubscriptions}
+              gcpProjects={gcpProjects}
             />
           ))}
         </div>

--- a/services/ui/src/components/workspace-tree/WorkspaceLeafRow.tsx
+++ b/services/ui/src/components/workspace-tree/WorkspaceLeafRow.tsx
@@ -8,9 +8,15 @@ import { useCurrentUser, hasMinRole } from "../../hooks/useAuth";
 import { Badge, Button, ConfirmDialog, DriftBadge } from "../ui";
 import { RunModal } from "../RunModal";
 import { FileIcon, HelmChip } from "./icons";
-import { azureInfo } from "./paths";
+import { azureInfo, gcpInfo } from "./paths";
 import { BranchStatusChip, InlineLinkEditor, TreeRow } from "./primitives";
-import type { AwsAccountLite, AzureSubscriptionLite, Run, Workspace } from "./types";
+import type {
+  AwsAccountLite,
+  AzureSubscriptionLite,
+  GcpProjectLite,
+  Run,
+  Workspace,
+} from "./types";
 
 export function WorkspaceLeafRow({
   workspace,
@@ -20,6 +26,7 @@ export function WorkspaceLeafRow({
   onChanged,
   awsAccounts,
   azureSubscriptions,
+  gcpProjects,
 }: {
   workspace: Workspace;
   displayName: string;
@@ -28,6 +35,7 @@ export function WorkspaceLeafRow({
   onChanged: () => void;
   awsAccounts: AwsAccountLite[];
   azureSubscriptions: AzureSubscriptionLite[];
+  gcpProjects: GcpProjectLite[];
 }) {
   const user = useCurrentUser();
   const [busy, setBusy] = useState<null | string>(null);
@@ -55,6 +63,10 @@ export function WorkspaceLeafRow({
   const linkedAzureSub = azureSubscriptions.find(
     (s) => s.id === workspace.azure_subscription_id,
   );
+  // GCP mirror of the Azure link: auto-derived from the gcp/project-<id>/ path
+  // or the explicit gcp_project_id link. Read-only in the row.
+  const isGcp = !!workspace.gcp_project_id || !!gcpInfo(workspace);
+  const linkedGcpProject = gcpProjects.find((p) => p.id === workspace.gcp_project_id);
 
   // ─── State-lock status (lazy-fetched on expand) ────────────────────────
   type LockStatus = { held: boolean; run_id?: string | null; acquired_at?: string | null };
@@ -113,7 +125,7 @@ export function WorkspaceLeafRow({
   // (server normalizes to NULL). Returns whether the save succeeded so the
   // InlineLinkEditor knows whether to collapse.
   async function saveLink(
-    field: "state_aws_account_id" | "azure_subscription_id",
+    field: "state_aws_account_id" | "azure_subscription_id" | "state_backend",
     value: string,
     busyKey: string,
   ): Promise<boolean> {
@@ -304,6 +316,37 @@ export function WorkspaceLeafRow({
                   </span>
                 </div>
               )}
+              {isGcp && (
+                // Read-only: the project is auto-derived from the workspace path
+                // (gcp/project-<id>/…) at import, mirroring the AWS/Azure links.
+                <div title="Auto-derived from the workspace path (gcp/project-<id>/…); injects the project's service-account credentials for the google provider.">
+                  <span className="text-slate-400">gcp project</span>{" "}
+                  <span className="font-mono text-[11px]">
+                    {linkedGcpProject
+                      ? `${linkedGcpProject.name} (${linkedGcpProject.project_id})`
+                      : workspace.gcp_project_id
+                        ? workspace.gcp_project_id
+                        : "(auto-derived from path)"}
+                  </span>
+                </div>
+              )}
+              <div title="Where this workspace's Terraform state is stored. azureblob/gcs require a linked subscription/project whose storage target is configured — otherwise the save is rejected.">
+                <span className="text-slate-400">state backend</span>{" "}
+                {hasMinRole(user, "admin") ? (
+                  <select
+                    value={workspace.state_backend ?? "s3"}
+                    disabled={busy === "rebind-backend"}
+                    onChange={(e) => saveLink("state_backend", e.target.value, "rebind-backend")}
+                    className="ml-1 rounded border border-brand-border bg-white px-1.5 py-0.5 font-mono text-[11px] text-brand-text dark:border-slate-700 dark:bg-slate-950 dark:text-slate-100"
+                  >
+                    <option value="s3">s3</option>
+                    <option value="azureblob">azureblob</option>
+                    <option value="gcs">gcs</option>
+                  </select>
+                ) : (
+                  <span className="font-mono text-[11px]">{workspace.state_backend ?? "s3"}</span>
+                )}
+              </div>
               {workspace.repo_url && (
                 <div className="sm:col-span-2">
                   <span className="text-slate-400">repo</span>{" "}

--- a/services/ui/src/components/workspace-tree/groups.tsx
+++ b/services/ui/src/components/workspace-tree/groups.tsx
@@ -4,7 +4,7 @@
 
 import { ReactNode, useEffect, useMemo, useState } from "react";
 import { Badge, Card } from "../ui";
-import { AzureIcon, CloudIcon, FolderIcon } from "./icons";
+import { AzureIcon, CloudIcon, FolderIcon, GcpIcon } from "./icons";
 import {
   buildFolderTree,
   collectNodeWorkspaces,
@@ -17,6 +17,7 @@ import type {
   AwsAccountLite,
   AzureSubscriptionLite,
   ExpandSignal,
+  GcpProjectLite,
   Run,
   Workspace,
 } from "./types";
@@ -29,6 +30,7 @@ function FolderTreeBody({
   expandSignal,
   awsAccounts,
   azureSubscriptions,
+  gcpProjects,
 }: {
   node: FolderNode;
   depth: number;
@@ -37,6 +39,7 @@ function FolderTreeBody({
   expandSignal: ExpandSignal;
   awsAccounts: AwsAccountLite[];
   azureSubscriptions: AzureSubscriptionLite[];
+  gcpProjects: GcpProjectLite[];
 }) {
   const folderNames = [...node.folders.keys()].sort();
   const wsSorted = [...node.workspaces].sort((a, b) => a.leaf.localeCompare(b.leaf));
@@ -52,6 +55,7 @@ function FolderTreeBody({
           expandSignal={expandSignal}
           awsAccounts={awsAccounts}
           azureSubscriptions={azureSubscriptions}
+          gcpProjects={gcpProjects}
         />
       ))}
       {wsSorted.map(({ ws, leaf }) => (
@@ -64,6 +68,7 @@ function FolderTreeBody({
           onChanged={onChanged}
           awsAccounts={awsAccounts}
           azureSubscriptions={azureSubscriptions}
+          gcpProjects={gcpProjects}
         />
       ))}
     </div>
@@ -78,6 +83,7 @@ function FolderGroup({
   expandSignal,
   awsAccounts,
   azureSubscriptions,
+  gcpProjects,
 }: {
   folder: FolderNode;
   depth: number;
@@ -86,6 +92,7 @@ function FolderGroup({
   expandSignal: ExpandSignal;
   awsAccounts: AwsAccountLite[];
   azureSubscriptions: AzureSubscriptionLite[];
+  gcpProjects: GcpProjectLite[];
 }) {
   // Folders start collapsed so the dashboard isn't a wall of nested rows on
   // load — operators expand the levels they care about. The chevron state is
@@ -122,6 +129,7 @@ function FolderGroup({
           expandSignal={expandSignal}
           awsAccounts={awsAccounts}
           azureSubscriptions={azureSubscriptions}
+          gcpProjects={gcpProjects}
         />
       )}
     </div>
@@ -139,6 +147,7 @@ function RegionGroup({
   expandSignal,
   awsAccounts,
   azureSubscriptions,
+  gcpProjects,
 }: {
   region: string;
   workspaces: Workspace[];
@@ -148,6 +157,7 @@ function RegionGroup({
   expandSignal: ExpandSignal;
   awsAccounts: AwsAccountLite[];
   azureSubscriptions: AzureSubscriptionLite[];
+  gcpProjects: GcpProjectLite[];
 }) {
   const [open, setOpen] = useState(defaultOpen);
   useEffect(() => {
@@ -181,6 +191,7 @@ function RegionGroup({
           expandSignal={expandSignal}
           awsAccounts={awsAccounts}
           azureSubscriptions={azureSubscriptions}
+          gcpProjects={gcpProjects}
         />
       )}
     </div>
@@ -207,6 +218,7 @@ function CloudGroupCard({
   expandSignal,
   awsAccounts,
   azureSubscriptions,
+  gcpProjects,
 }: {
   icon: ReactNode;
   label: ReactNode;
@@ -219,6 +231,7 @@ function CloudGroupCard({
   expandSignal: ExpandSignal;
   awsAccounts: AwsAccountLite[];
   azureSubscriptions: AzureSubscriptionLite[];
+  gcpProjects: GcpProjectLite[];
 }) {
   const [open, setOpen] = useState(defaultOpen);
   useEffect(() => {
@@ -267,6 +280,7 @@ function CloudGroupCard({
                 expandSignal={expandSignal}
                 awsAccounts={awsAccounts}
                 azureSubscriptions={azureSubscriptions}
+                gcpProjects={gcpProjects}
               />
             ))}
         </div>
@@ -291,6 +305,7 @@ export function AccountGroup({
   expandSignal: ExpandSignal;
   awsAccounts: AwsAccountLite[];
   azureSubscriptions: AzureSubscriptionLite[];
+  gcpProjects: GcpProjectLite[];
 }) {
   return (
     <CloudGroupCard
@@ -337,6 +352,7 @@ export function AzureSubscriptionGroup({
   expandSignal: ExpandSignal;
   awsAccounts: AwsAccountLite[];
   azureSubscriptions: AzureSubscriptionLite[];
+  gcpProjects: GcpProjectLite[];
 }) {
   const subId = sub?.subscription_id ?? guid ?? "";
   return (
@@ -360,6 +376,54 @@ export function AzureSubscriptionGroup({
         )
       }
       scopeLabel={sub ? `${sub.name} (${subId})` : `subscription ${subId}`}
+      {...rest}
+    />
+  );
+}
+
+// ─── Project group (GCP) ───────────────────────────────────────────────────────
+
+export function GcpProjectGroup({
+  proj,
+  projectId,
+  ...rest
+}: {
+  // The registered project, when this group is linked/matched to one.
+  proj?: GcpProjectLite;
+  // The project id parsed from the repo path when no registration matches
+  // (workspaces synced but not yet linked / not registered).
+  projectId?: string;
+  byRegion: Record<string, Workspace[]>;
+  latestByWs: Map<string, Run>;
+  defaultOpen: boolean;
+  onChanged: () => void;
+  expandSignal: ExpandSignal;
+  awsAccounts: AwsAccountLite[];
+  azureSubscriptions: AzureSubscriptionLite[];
+  gcpProjects: GcpProjectLite[];
+}) {
+  const pid = proj?.project_id ?? projectId ?? "";
+  return (
+    <CloudGroupCard
+      icon={<GcpIcon />}
+      label={
+        proj ? (
+          <>
+            {proj.name}{" "}
+            <span className="ml-1 font-mono text-xs font-normal text-slate-500">{pid}</span>
+          </>
+        ) : (
+          <span className="font-mono">project-{pid}</span>
+        )
+      }
+      badge={
+        proj ? (
+          <Badge tone="success">configured</Badge>
+        ) : (
+          <Badge tone="warning">project not registered</Badge>
+        )
+      }
+      scopeLabel={proj ? `${proj.name} (${pid})` : `project ${pid}`}
       {...rest}
     />
   );

--- a/services/ui/src/components/workspace-tree/icons.tsx
+++ b/services/ui/src/components/workspace-tree/icons.tsx
@@ -71,3 +71,26 @@ export function AzureIcon() {
     </svg>
   );
 }
+
+// GCP project group icon — a cloud+check in emerald, distinct from the orange
+// AWS CloudIcon and blue AzureIcon at a glance. Stroke-based (matches the
+// `td-i-gcp` sprite geometry) rather than filled.
+export function GcpIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+      className="text-emerald-500 dark:text-emerald-400"
+    >
+      <path d="M7 17a4 4 0 0 1 1-7.9 6 6 0 0 1 11 2A3.5 3.5 0 0 1 18 18z" />
+      <path d="M10 13l2 2 3-4" />
+    </svg>
+  );
+}

--- a/services/ui/src/components/workspace-tree/paths.test.ts
+++ b/services/ui/src/components/workspace-tree/paths.test.ts
@@ -4,6 +4,7 @@ import {
   buildFolderTree,
   collectNodeWorkspaces,
   countNodeWorkspaces,
+  gcpInfo,
   workspacePathSegments,
 } from "./paths";
 import type { Workspace } from "./types";
@@ -51,6 +52,30 @@ describe("azureInfo", () => {
   });
 });
 
+describe("gcpInfo", () => {
+  it("parses project id + region from a gcp/project path", () => {
+    const w = ws({
+      name: "network",
+      region: "global",
+      tf_working_dir: "gcp/project-acme-prod-1234/us-central1/network",
+    });
+    expect(gcpInfo(w)).toEqual({ projectId: "acme-prod-1234", region: "us-central1" });
+  });
+
+  it("returns null for a non-gcp path", () => {
+    expect(gcpInfo(ws({ name: "vpc", tf_working_dir: "account-123/us-east-1/vpc" }))).toBeNull();
+  });
+
+  it("returns null when 'gcp' is present but the second segment isn't a project", () => {
+    expect(gcpInfo(ws({ name: "x", tf_working_dir: "gcp/us-central1/x" }))).toBeNull();
+  });
+
+  it("falls back to ws.region when the path omits a region segment", () => {
+    const w = ws({ name: "net", region: "europe-west1", tf_working_dir: "gcp/project-p1" });
+    expect(gcpInfo(w)).toEqual({ projectId: "p1", region: "europe-west1" });
+  });
+});
+
 describe("workspacePathSegments", () => {
   it("strips account-<id>/<region> for an AWS path", () => {
     const w = ws({
@@ -77,6 +102,24 @@ describe("workspacePathSegments", () => {
       tf_working_dir: "azure/subscription-x/eastus/openai/gpt4",
     });
     expect(workspacePathSegments(w)).toEqual({ folders: ["openai"], leaf: "gpt4" });
+  });
+
+  it("strips gcp/project-<id>/<region> so the leaf sits at the region", () => {
+    const w = ws({
+      name: "network",
+      region: "global",
+      tf_working_dir: "gcp/project-acme-prod-1234/us-central1/network",
+    });
+    expect(workspacePathSegments(w)).toEqual({ folders: [], leaf: "network" });
+  });
+
+  it("keeps intermediate folders under a gcp region", () => {
+    const w = ws({
+      name: "gke",
+      region: "global",
+      tf_working_dir: "gcp/project-p1/us-central1/platform/gke",
+    });
+    expect(workspacePathSegments(w)).toEqual({ folders: ["platform"], leaf: "gke" });
   });
 
   it("falls back to the workspace name for an empty or '.' path", () => {

--- a/services/ui/src/components/workspace-tree/paths.ts
+++ b/services/ui/src/components/workspace-tree/paths.ts
@@ -19,6 +19,20 @@ export function azureInfo(ws: Workspace): { guid: string; region: string } | nul
 }
 
 /**
+ * Detect the GCP layout encoded in a workspace's repo path. The convention
+ * mirrors Azure's as `gcp/project-<project_id>/<region>/…`. Returns the
+ * project id + region when the path matches, else null. Path fallback for
+ * grouping — the explicit `workspace.gcp_project_id` link wins when present.
+ */
+export function gcpInfo(ws: Workspace): { projectId: string; region: string } | null {
+  const parts = (ws.tf_working_dir ?? "").trim().split("/").filter(Boolean);
+  if (parts[0] !== "gcp") return null;
+  const m = (parts[1] ?? "").match(/^project-(.+)$/);
+  if (!m) return null;
+  return { projectId: m[1], region: parts[2] ?? ws.region };
+}
+
+/**
  * Split a workspace's `tf_working_dir` into intermediate folder segments + a
  * leaf name. We strip the leading `account-<id>/<region>/` to leave just the
  * path *within* the (account, region) slot. The leaf is what the row should
@@ -38,6 +52,12 @@ export function workspacePathSegments(ws: Workspace): { folders: string[]; leaf:
   // the leaf sits directly under its region — same shape as an AWS account.
   let regionToStrip = ws.region;
   if (parts[0] === "azure" && /^subscription-/.test(parts[1] ?? "")) {
+    parts.shift();
+    parts.shift();
+    regionToStrip = parts[0] ?? ws.region;
+  } else if (parts[0] === "gcp" && /^project-/.test(parts[1] ?? "")) {
+    // Strip the `gcp/project-<id>` pair (the project is the top-level group)
+    // and treat the next segment as the region to strip — same shape as Azure.
     parts.shift();
     parts.shift();
     regionToStrip = parts[0] ?? ws.region;

--- a/services/ui/src/components/workspace-tree/types.ts
+++ b/services/ui/src/components/workspace-tree/types.ts
@@ -28,6 +28,13 @@ export type Workspace = {
   // azurerm provider authenticates without the Azure CLI. Drives top-level
   // grouping (an Azure subscription gets its own group, like an AWS account).
   azure_subscription_id?: string | null;
+  // GCP project this workspace deploys into. When set, the executor writes the
+  // project's SA-key JSON and exports GOOGLE_* env vars so the google provider
+  // authenticates. Drives top-level grouping (a GCP project gets its own group,
+  // like an AWS account / Azure subscription).
+  gcp_project_id?: string | null;
+  // Where Terraform state is stored: "s3" (default), "azureblob", or "gcs".
+  state_backend?: string;
   // Workspace kind. "terraform" (default) drives the existing plan/apply
   // pipeline; "helm" reinterprets the same plan|apply|destroy commands as
   // helm diff/upgrade/uninstall against `cluster_id`. Optional on the wire so
@@ -58,6 +65,15 @@ export type AzureSubscriptionLite = {
   // The Azure subscription GUID (what the `azure/subscription-<guid>/` repo
   // path encodes — used to match path-detected workspaces to a registration).
   subscription_id: string;
+  name: string;
+};
+
+export type GcpProjectLite = {
+  // TDT primary key (what `workspace.gcp_project_id` stores).
+  id: string;
+  // The GCP project id (what the `gcp/project-<id>/` repo path encodes — used
+  // to match path-detected workspaces to a registration).
+  project_id: string;
   name: string;
 };
 

--- a/services/ui/src/pages/CloudProviders.tsx
+++ b/services/ui/src/pages/CloudProviders.tsx
@@ -1,18 +1,21 @@
 import { useState } from "react";
 import AwsAccounts from "./AwsAccounts";
 import AzureSubscriptions from "./AzureSubscriptions";
+import GcpProjects from "./GcpProjects";
 import Clusters from "./Clusters";
 
 /**
  * Cloud resources settings tab.
  *
- * Hosts a sub-tab per resource type: AWS accounts, Azure subscriptions, and
- * Kubernetes clusters (for Helm workspaces). One place for all infra creds —
- * future providers (GCP, Cloudflare) drop in here without re-shaping Settings.
+ * Hosts a sub-tab per resource type: AWS accounts, Azure subscriptions, GCP
+ * projects, and Kubernetes clusters (for Helm workspaces). One place for all
+ * infra creds — future providers (Cloudflare, …) drop in here without
+ * re-shaping Settings.
  */
 const PROVIDERS = [
   { id: "aws", label: "AWS", render: () => <AwsAccounts /> },
   { id: "azure", label: "Azure", render: () => <AzureSubscriptions /> },
+  { id: "gcp", label: "GCP", render: () => <GcpProjects /> },
   { id: "clusters", label: "Kubernetes", render: () => <Clusters /> },
 ] as const;
 

--- a/services/ui/src/pages/Dashboard.tsx
+++ b/services/ui/src/pages/Dashboard.tsx
@@ -24,6 +24,7 @@ import GitImport from "../components/GitImport";
 import WorkspaceTree, {
   type AwsAccountLite,
   type AzureSubscriptionLite,
+  type GcpProjectLite,
   type Run,
   type Workspace,
 } from "../components/WorkspaceTree";
@@ -202,6 +203,7 @@ export default function Dashboard() {
   const [runs, setRuns] = useState<Run[]>([]);
   const [awsAccounts, setAwsAccounts] = useState<AwsAccountLite[]>([]);
   const [azureSubscriptions, setAzureSubscriptions] = useState<AzureSubscriptionLite[]>([]);
+  const [gcpProjects, setGcpProjects] = useState<GcpProjectLite[]>([]);
   const [err, setErr] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -239,18 +241,21 @@ export default function Dashboard() {
     if (opts.silent) setRefreshing(true);
     else setLoading(true);
     try {
-      const [w, r, a, az] = await Promise.all([
+      const [w, r, a, az, gc] = await Promise.all([
         api.get("/v1/workspaces"),
         api.get("/v1/runs"),
         // Admin-gated; viewers may 403 — render account rows without display names then.
         api.get("/v1/aws-accounts").catch(() => ({ data: [] })),
         // Same: used to label Azure subscription groups + the link selector.
         api.get("/v1/azure-subscriptions").catch(() => ({ data: [] })),
+        // Same: used to label GCP project groups + the state-backend selector.
+        api.get("/v1/gcp-projects").catch(() => ({ data: [] })),
       ]);
       setWorkspaces(w.data);
       setRuns(r.data);
       setAwsAccounts(a.data);
       setAzureSubscriptions(az.data);
+      setGcpProjects(gc.data);
       setLastRefreshed(new Date());
       setErr(null);
     } catch (e: any) {
@@ -621,6 +626,7 @@ export default function Dashboard() {
           runs={runs}
           awsAccounts={awsAccounts}
           azureSubscriptions={azureSubscriptions}
+          gcpProjects={gcpProjects}
           onChanged={load}
         />
       )}

--- a/services/ui/src/pages/GcpProjects.tsx
+++ b/services/ui/src/pages/GcpProjects.tsx
@@ -15,45 +15,46 @@ import {
   Spinner,
 } from "../components/ui";
 
-type AzureSubscription = {
+type GcpProject = {
   id: string;
   business_unit_id: string;
-  subscription_id: string;
-  tenant_id: string;
-  client_id: string;
+  project_id: string;
+  client_email: string;
   name: string;
   description?: string | null;
-  default_location: string;
-  state_storage_account?: string | null;
-  state_container?: string | null;
-  client_secret_masked: string;
+  default_region: string;
+  state_bucket?: string | null;
+  state_prefix?: string | null;
+  service_account_masked: string;
 };
 
 type FormState = {
-  subscription_id: string;
-  tenant_id: string;
-  client_id: string;
-  client_secret: string;
+  project_id: string;
   name: string;
   description: string;
-  default_location: string;
-  state_storage_account: string;
-  state_container: string;
+  default_region: string;
+  state_bucket: string;
+  state_prefix: string;
+  service_account_json: string;
 };
 
 const EMPTY: FormState = {
-  subscription_id: "",
-  tenant_id: "",
-  client_id: "",
-  client_secret: "",
+  project_id: "",
   name: "",
   description: "",
-  default_location: "eastus",
-  state_storage_account: "",
-  state_container: "",
+  default_region: "us-central1",
+  state_bucket: "",
+  state_prefix: "",
+  service_account_json: "",
 };
 
-function SubForm({
+const TEXTAREA_CLS =
+  "block w-full rounded-md border border-brand-border bg-white px-3 py-2 font-mono text-xs " +
+  "text-brand-text placeholder-brand-muted transition-colors focus:border-brand-400 focus:outline-none " +
+  "focus:ring-2 focus:ring-brand-400/30 dark:border-slate-700/70 dark:bg-slate-950/60 " +
+  "dark:text-slate-100 dark:placeholder-slate-500";
+
+function ProjForm({
   initial,
   editing,
   onSubmit,
@@ -79,7 +80,7 @@ function SubForm({
   return (
     <Card className="mb-6">
       <CardHeader>
-        <CardTitle>{editing ? "Edit Azure subscription" : "Add Azure subscription"}</CardTitle>
+        <CardTitle>{editing ? "Edit GCP project" : "Add GCP project"}</CardTitle>
       </CardHeader>
       <CardBody>
         <form onSubmit={submit} className="grid gap-3 md:grid-cols-2">
@@ -88,47 +89,33 @@ function SubForm({
             <Input value={f.name} onChange={(e) => update("name", e.target.value)} required />
           </div>
           <div>
-            <Label>Subscription ID</Label>
+            <Label>Project ID</Label>
             <Input
-              placeholder="00000000-0000-0000-0000-000000000000"
-              value={f.subscription_id}
-              onChange={(e) => update("subscription_id", e.target.value)}
+              placeholder="acme-prod-1234"
+              value={f.project_id}
+              onChange={(e) => update("project_id", e.target.value)}
               required
               disabled={editing}
             />
           </div>
           <div>
-            <Label>Tenant ID</Label>
-            <Input
-              placeholder="00000000-0000-0000-0000-000000000000"
-              value={f.tenant_id}
-              onChange={(e) => update("tenant_id", e.target.value)}
-              required
-              disabled={editing}
-            />
-          </div>
-          <div>
-            <Label>Client (application) ID</Label>
-            <Input
-              placeholder="00000000-0000-0000-0000-000000000000"
-              value={f.client_id}
-              onChange={(e) => update("client_id", e.target.value)}
-              required
-              disabled={editing}
-            />
-          </div>
-          <div>
-            <Label>Default location</Label>
-            <Input value={f.default_location} onChange={(e) => update("default_location", e.target.value)} />
+            <Label>Default region</Label>
+            <Input value={f.default_region} onChange={(e) => update("default_region", e.target.value)} />
           </div>
           <div className="md:col-span-2">
-            <Label>Client secret {editing && <span className="text-xs text-slate-500">(leave blank to keep current)</span>}</Label>
-            <Input
-              type="password"
-              value={f.client_secret}
-              onChange={(e) => update("client_secret", e.target.value)}
+            <Label>
+              Service-account key JSON{" "}
+              {editing && <span className="text-xs text-slate-500">(leave blank to keep current)</span>}
+            </Label>
+            <textarea
+              className={TEXTAREA_CLS}
+              rows={6}
+              placeholder='{ "type": "service_account", "project_id": "…", "private_key": "…", "client_email": "…" }'
+              value={f.service_account_json}
+              onChange={(e) => update("service_account_json", e.target.value)}
               required={!editing}
-              autoComplete="new-password"
+              autoComplete="off"
+              spellCheck={false}
             />
           </div>
           <div className="md:col-span-2">
@@ -137,28 +124,24 @@ function SubForm({
           </div>
           <div className="md:col-span-2 mt-1 border-t border-slate-200 pt-3 dark:border-slate-700">
             <p className="text-xs font-medium text-slate-600 dark:text-slate-300">
-              Azure Blob state backend (optional)
+              GCS state backend (optional)
             </p>
             <p className="text-[11px] text-slate-500">
-              Set both to let workspaces store Terraform state in Blob using this
-              SP (grant it “Storage Blob Data Contributor”). Leave blank to keep state in S3.
+              Set a bucket to let workspaces store Terraform state in GCS using this
+              project's service account. Leave blank to keep state in S3.
             </p>
           </div>
           <div>
-            <Label>Storage account</Label>
+            <Label>State bucket</Label>
             <Input
-              placeholder="acmetfstate"
-              value={f.state_storage_account}
-              onChange={(e) => update("state_storage_account", e.target.value)}
+              placeholder="acme-prod-tfstate"
+              value={f.state_bucket}
+              onChange={(e) => update("state_bucket", e.target.value)}
             />
           </div>
           <div>
-            <Label>Container</Label>
-            <Input
-              placeholder="tfstate"
-              value={f.state_container}
-              onChange={(e) => update("state_container", e.target.value)}
-            />
+            <Label>State prefix (optional)</Label>
+            <Input value={f.state_prefix} onChange={(e) => update("state_prefix", e.target.value)} />
           </div>
           {error && (
             <p className="md:col-span-2 rounded-md bg-red-50 px-3 py-2 text-sm text-red-700 dark:bg-red-950/40 dark:text-red-300">
@@ -166,7 +149,7 @@ function SubForm({
             </p>
           )}
           <div className="md:col-span-2 mt-2 flex items-center gap-2">
-            <Button type="submit" disabled={busy}>{busy ? <Spinner /> : editing ? "Save" : "Add subscription"}</Button>
+            <Button type="submit" disabled={busy}>{busy ? <Spinner /> : editing ? "Save" : "Add project"}</Button>
             <Button type="button" variant="ghost" onClick={onCancel} disabled={busy}>Cancel</Button>
           </div>
         </form>
@@ -175,16 +158,15 @@ function SubForm({
   );
 }
 
-export default function AzureSubscriptions() {
-  const [rows, setRows] = useState<AzureSubscription[]>([]);
+export default function GcpProjects() {
+  const [rows, setRows] = useState<GcpProject[]>([]);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
-  const [showForm, setShowForm] = useState<null | { mode: "create" | "edit"; row?: AzureSubscription }>(null);
+  const [showForm, setShowForm] = useState<null | { mode: "create" | "edit"; row?: GcpProject }>(null);
   const [busy, setBusy] = useState(false);
   const [formError, setFormError] = useState<string | null>(null);
   const [testResult, setTestResult] = useState<Record<string, { ok: boolean; detail?: string }>>({});
-  // Subscription pending deletion, awaiting in-app confirmation (no native popups).
-  const [pendingDelete, setPendingDelete] = useState<AzureSubscription | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<GcpProject | null>(null);
   const [actionBusy, setActionBusy] = useState(false);
   const [actionErr, setActionErr] = useState<string | null>(null);
 
@@ -192,10 +174,10 @@ export default function AzureSubscriptions() {
     setLoading(true);
     setErr(null);
     try {
-      const r = await api.get("/v1/azure-subscriptions");
+      const r = await api.get("/v1/gcp-projects");
       setRows(r.data);
     } catch (e: any) {
-      setErr(e?.response?.data?.detail ?? "Failed to load Azure subscriptions");
+      setErr(e?.response?.data?.detail ?? "Failed to load GCP projects");
     } finally {
       setLoading(false);
     }
@@ -207,21 +189,16 @@ export default function AzureSubscriptions() {
     setBusy(true);
     setFormError(null);
     try {
+      const body: any = { ...f };
+      // Empty optional fields → null (avoid storing "").
+      body.state_bucket = body.state_bucket || null;
+      body.state_prefix = body.state_prefix || null;
       if (showForm?.mode === "create") {
-        // Empty Blob-state fields must be omitted — the create schema pattern
-        // rejects "" (they're optional, so absent = null).
-        const body: any = { ...f };
-        if (!body.state_storage_account) delete body.state_storage_account;
-        if (!body.state_container) delete body.state_container;
-        await api.post("/v1/azure-subscriptions", body);
+        await api.post("/v1/gcp-projects", body);
       } else if (showForm?.mode === "edit" && showForm.row) {
-        // Skip empty client_secret on edit so we keep the existing one.
-        const body: any = { ...f };
-        if (!body.client_secret) delete body.client_secret;
-        // Empty string clears the Blob-state config (send null).
-        body.state_storage_account = body.state_storage_account || null;
-        body.state_container = body.state_container || null;
-        await api.put(`/v1/azure-subscriptions/${showForm.row.id}`, body);
+        // Blank SA key on edit → keep the existing one.
+        if (!body.service_account_json) delete body.service_account_json;
+        await api.put(`/v1/gcp-projects/${showForm.row.id}`, body);
       }
       setShowForm(null);
       await refresh();
@@ -237,7 +214,7 @@ export default function AzureSubscriptions() {
     setActionBusy(true);
     setActionErr(null);
     try {
-      await api.delete(`/v1/azure-subscriptions/${pendingDelete.id}`);
+      await api.delete(`/v1/gcp-projects/${pendingDelete.id}`);
       setPendingDelete(null);
       await refresh();
     } catch (e: any) {
@@ -247,36 +224,41 @@ export default function AzureSubscriptions() {
     }
   }
 
-  async function onTest(row: AzureSubscription) {
+  async function onTest(row: GcpProject) {
     setTestResult((p) => ({ ...p, [row.id]: { ok: false, detail: "Testing…" } }));
     try {
-      const r = await api.post(`/v1/azure-subscriptions/${row.id}/test`);
+      const r = await api.post(`/v1/gcp-projects/${row.id}/test`);
       setTestResult((p) => ({ ...p, [row.id]: r.data }));
     } catch (e: any) {
       setTestResult((p) => ({ ...p, [row.id]: { ok: false, detail: e?.response?.data?.detail ?? "Test failed" } }));
     }
   }
 
-  function startEdit(row: AzureSubscription) {
+  async function onCreateBucket(row: GcpProject) {
+    setTestResult((p) => ({ ...p, [row.id]: { ok: false, detail: "Creating bucket…" } }));
+    try {
+      const r = await api.post(`/v1/gcp-projects/${row.id}/bucket`);
+      setTestResult((p) => ({ ...p, [row.id]: r.data }));
+    } catch (e: any) {
+      setTestResult((p) => ({ ...p, [row.id]: { ok: false, detail: e?.response?.data?.detail ?? "Bucket create failed" } }));
+    }
+  }
+
+  function startEdit(row: GcpProject) {
     setFormError(null);
-    setShowForm({
-      mode: "edit",
-      row,
-    });
+    setShowForm({ mode: "edit", row });
   }
 
   const initialForm: FormState =
     showForm?.mode === "edit" && showForm.row
       ? {
-          subscription_id: showForm.row.subscription_id,
-          tenant_id: showForm.row.tenant_id,
-          client_id: showForm.row.client_id,
-          client_secret: "",
+          project_id: showForm.row.project_id,
           name: showForm.row.name,
           description: showForm.row.description ?? "",
-          default_location: showForm.row.default_location,
-          state_storage_account: showForm.row.state_storage_account ?? "",
-          state_container: showForm.row.state_container ?? "",
+          default_region: showForm.row.default_region,
+          state_bucket: showForm.row.state_bucket ?? "",
+          state_prefix: showForm.row.state_prefix ?? "",
+          service_account_json: "",
         }
       : EMPTY;
 
@@ -284,20 +266,19 @@ export default function AzureSubscriptions() {
     <div>
       <div className="mb-4 flex items-center justify-between">
         <div>
-          <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">Azure subscriptions</h3>
+          <h3 className="text-sm font-semibold text-slate-900 dark:text-slate-100">GCP projects</h3>
           <p className="text-xs text-slate-500">
-            Service-principal credentials used by the <code>azurerm</code> provider.
-            Optionally set a Blob storage account + container below to store Terraform
-            state in Azure Blob instead of S3 (per-workspace, via the state-backend selector).
+            Service-account keys used by the <code>google</code> provider. Optionally set a
+            GCS bucket to store Terraform state in GCS (per-workspace, via the state-backend selector).
           </p>
         </div>
         {!showForm && (
-          <Button onClick={() => { setFormError(null); setShowForm({ mode: "create" }); }}>+ Add subscription</Button>
+          <Button onClick={() => { setFormError(null); setShowForm({ mode: "create" }); }}>+ Add project</Button>
         )}
       </div>
 
       {showForm && (
-        <SubForm
+        <ProjForm
           key={showForm.row?.id ?? "create"}
           initial={initialForm}
           editing={showForm.mode === "edit"}
@@ -319,7 +300,7 @@ export default function AzureSubscriptions() {
       ) : err ? (
         <Card><CardBody className="text-sm text-red-600 dark:text-red-300">{err}</CardBody></Card>
       ) : rows.length === 0 ? (
-        <EmptyState title="No Azure subscriptions yet" description="Add one to onboard an Azure subscription for terraform runs." />
+        <EmptyState title="No GCP projects yet" description="Add one to onboard a GCP project for terraform runs." />
       ) : (
         <div className="space-y-3">
           {rows.map((row) => {
@@ -331,17 +312,17 @@ export default function AzureSubscriptions() {
                     <div className="min-w-0">
                       <div className="flex items-center gap-2">
                         <span className="text-sm font-semibold text-slate-900 dark:text-slate-100">{row.name}</span>
-                        <Badge tone="info">azure</Badge>
+                        <Badge tone="info">gcp</Badge>
                       </div>
                       <p className="mt-1 font-mono text-[11px] text-slate-500">
-                        sub {row.subscription_id} · tenant {row.tenant_id}
+                        project {row.project_id} · region {row.default_region}
                       </p>
                       <p className="mt-0.5 font-mono text-[11px] text-slate-500">
-                        client {row.client_id} · secret {row.client_secret_masked}
+                        sa {row.service_account_masked}
                       </p>
-                      {row.state_storage_account && row.state_container && (
+                      {row.state_bucket && (
                         <p className="mt-0.5 font-mono text-[11px] text-slate-500">
-                          blob state {row.state_storage_account}/{row.state_container}
+                          gcs state {row.state_bucket}{row.state_prefix ? `/${row.state_prefix}` : ""}
                         </p>
                       )}
                       {row.description && <p className="mt-1 text-xs text-slate-500">{row.description}</p>}
@@ -353,8 +334,11 @@ export default function AzureSubscriptions() {
                     </div>
                     <div className="flex shrink-0 gap-2">
                       <Button size="sm" variant="ghost" onClick={() => onTest(row)}>Test creds</Button>
+                      {row.state_bucket && (
+                        <Button size="sm" variant="ghost" onClick={() => onCreateBucket(row)}>Create bucket</Button>
+                      )}
                       <Button size="sm" variant="ghost" onClick={() => startEdit(row)}>Edit</Button>
-                      <Button size="sm" variant="warning" onClick={() => { setActionErr(null); setPendingDelete(row); }}>Delete</Button>
+                      <Button size="sm" variant="danger" onClick={() => { setActionErr(null); setPendingDelete(row); }}>Delete</Button>
                     </div>
                   </div>
                 </CardBody>
@@ -367,10 +351,10 @@ export default function AzureSubscriptions() {
       <ConfirmDialog
         open={pendingDelete !== null}
         tone="danger"
-        title="Delete Azure subscription"
+        title="Delete GCP project"
         message={
           <>
-            Delete Azure subscription <strong>"{pendingDelete?.name}"</strong>? Workspaces linked to
+            Delete GCP project <strong>"{pendingDelete?.name}"</strong>? Workspaces linked to
             it will be unlinked.
           </>
         }


### PR DESCRIPTION
## Summary

Adds **Google Cloud as a first-class provider** (full parity with the existing Azure vertical slice) and makes **Terraform state storage pluggable per workspace** — S3 (default), **Azure Blob**, or **GCS** — behind the API's HTTP state backend. Both features share one backbone: the executor always talks Terraform's `backend "http"` to the API, so all state-store selection is API-side and the executor never learns which store is behind it. Locking stays DB-side (Postgres advisory locks), unchanged.

Also adds GitHub Actions (this repo previously only had Forgejo CI): PR checks + tag-triggered Releases.

## What's included

**GCP provider (full parity with Azure)**
- `gcp_projects` model / schema / service / router — BU-scoped CRUD, Fernet-encrypted SA-key JSON (distinct HKDF salt), masked responses, `POST /test` (google-auth), `POST /bucket` (create GCS bucket).
- Executor injects `GOOGLE_*` creds; `entrypoint.sh` writes the SA key to a `0600` file → `GOOGLE_APPLICATION_CREDENTIALS` (mirrors the kubeconfig pattern). `TDT_CLOUD_PROVIDERS` now composes aws+azure+gcp.
- Git-path auto-link on import: `gcp/project-<id>/<region>/<stack>`.
- UI: `GcpProjects` settings tab, workspace-tree GCP grouping + icon, `/gcp` route.

**Pluggable state storage**
- `StateStore` protocol with `S3StateService` (unchanged), `AzureBlobStateService` (reuses the Azure SP over AAD), `GcsStateService` (reuses the GCP SA key). `routers/state.py:_service_for` selects by `workspaces.state_backend` (`s3` | `azureblob` | `gcs`).
- **RT-0007 state scoping and the 404/503/500 mapping are preserved byte-for-byte.**
- Azure Blob state fields on `azure_subscriptions` + `POST /container` admin endpoint.
- Per-workspace state-backend selector in the UI; create/update validate the required cloud linkage + storage target (else 422).

**Migrations** `038 → 039 → 040` (linear off `037`). `state_backend` has `server_default='s3'`, so every existing workspace is untouched.

**CI/CD** — `.github/workflows/ci.yml` (API pytest, UI type-check+build+vitest, non-blocking Trivy) on PRs; `.github/workflows/release.yml` cuts a Release with auto-generated notes on a `v*.*.*` tag (or manual dispatch).

## Verification

- **API:** 509 tests pass (489 existing — zero regressions — + 20 new), 4 skipped.
- **UI:** `tsc` clean, 60 vitest tests (6 new), production build succeeds.
- **Migrations:** apply + downgrade + re-apply cleanly on a real Postgres 16; `state_backend` backfills to `s3`.
- **Live local run:** isolated stack (own Postgres/LocalStack); container-boot migrations reached `040`; drove the full control plane over HTTP — GCP CRUD/test/masking, Azure Blob fields, and `state_backend` validation (422 negatives + `s3→gcs`/`azureblob` happy paths).
- **Docker:** API image builds from the regenerated lock with the new SDKs.

## Honest boundary

This exercises the entire **control plane**. It does **not** perform a real `terraform plan` writing state into an actual GCS bucket / Azure Blob container — that needs real cloud credentials (no local emulator is wired for those two). Those object-store paths are covered by mocked-SDK contract tests; the S3 path remains fully e2e-testable via LocalStack.

## New dependencies (API image)

`azure-identity`, `azure-storage-blob`, `google-cloud-storage`, `google-auth` — all pure-Python/manylinux wheels; `requirements.lock` regenerated, no Dockerfile system-package change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
