### PR TITLE
feat(deploy): add Helm chart for Kubernetes deployment

### DIFF
--- a/deploy/helm/terraducktel/.helmignore
+++ b/deploy/helm/terraducktel/.helmignore
@@ -1,0 +1,11 @@
+# Patterns to ignore when packaging the chart.
+.DS_Store
+.git/
+.gitignore
+*.tmp
+*.bak
+*.orig
+*.swp
+.idea/
+.vscode/
+ci/

--- a/deploy/helm/terraducktel/Chart.yaml
+++ b/deploy/helm/terraducktel/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: terraducktel
+description: |
+  Terraducktel (TDT) — self-hosted Terraform/Helm orchestration platform.
+  Packages the API, UI, drift-detector, liveness-detector, Postgres, LocalStack
+  (dev S3), and optional Forgejo + pg-backup for a Kubernetes deployment.
+type: application
+# Chart version — bump on chart changes.
+version: 0.1.0
+# The upstream app version this chart tracks (TDT is versioned in the API image).
+appVersion: "dev"
+keywords:
+  - terraform
+  - helm
+  - orchestration
+  - iac
+  - terraducktel
+home: https://github.com/mormor83/terraducktel
+maintainers:
+  - name: Terraducktel

--- a/deploy/helm/terraducktel/templates/NOTES.txt
+++ b/deploy/helm/terraducktel/templates/NOTES.txt
@@ -1,0 +1,49 @@
+
+Terraducktel ({{ .Chart.Name }}-{{ .Chart.Version }}) installed as release "{{ .Release.Name }}" in namespace "{{ .Release.Namespace }}".
+
+Components enabled:
+  api ............... {{ .Values.api.enabled }}
+  ui ................ {{ .Values.ui.enabled }}
+  postgres .......... {{ .Values.postgres.enabled }}
+  localstack ........ {{ .Values.localstack.enabled }}
+  drift-detector .... {{ .Values.driftDetector.enabled }}
+  liveness-detector . {{ .Values.livenessDetector.enabled }}
+  forgejo ........... {{ .Values.forgejo.enabled }}
+  pg-backup ......... {{ .Values.pgBackup.enabled }}
+
+1. Watch everything come up:
+     kubectl -n {{ .Release.Namespace }} get pods -w
+
+2. Open the UI (it proxies /api to the API pod itself):
+{{- if .Values.ingress.enabled }}
+     http://{{ .Values.ingress.host }}/
+{{- else if eq .Values.ui.service.type "NodePort" }}
+     kubectl -n {{ .Release.Namespace }} get svc ui   # note the NodePort, then hit http://<node-ip>:<nodePort>/
+{{- else }}
+     kubectl -n {{ .Release.Namespace }} port-forward svc/ui 8080:{{ .Values.ui.service.port }}
+     # then browse http://localhost:8080/
+{{- end }}
+
+{{- if .Values.seedUsers.enabled }}
+
+3. Dev login (seeded by the post-install hook — DEV ONLY):
+     admin@test.com / password123      (superadmin)
+     operator@test.com / password123
+     viewer@test.com / password123
+{{- end }}
+
+Caveats for the Kubernetes deployment:
+  * Executor launching is OFF (EXECUTOR_ENABLED=false). The compose stack spawns
+    executor containers via the host Docker socket, which does not exist in a
+    pod. The core platform (auth, workspaces, drift surfacing, state backend)
+    works without it. To run Terraform/Helm executions, wire an out-of-cluster
+    runtime (EXECUTOR_RUNTIME=ecs) or add a Kubernetes-Job executor runtime.
+  * LocalStack is a DEV stand-in for S3 (Terraform state). Production uses real
+    per-account S3 buckets.
+{{- if .Values.forgejo.enabled }}
+  * Forgejo needs the `forgejo` database, which the Postgres init script creates
+    only on a FRESH data directory. If you enabled Forgejo against an existing
+    Postgres volume, create the DB manually.
+{{- end }}
+  * Secrets in values.yaml are DEV DEFAULTS. Override them (or use
+    `existingSecret`) for any non-local cluster.

--- a/deploy/helm/terraducktel/templates/_helpers.tpl
+++ b/deploy/helm/terraducktel/templates/_helpers.tpl
@@ -1,0 +1,30 @@
+{{/*
+Common labels applied to every object. Kept deliberately small so selectors
+stay stable across upgrades (selectors use only the per-component `app` label).
+*/}}
+{{- define "tdt.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/part-of: terraducktel
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- end -}}
+
+{{/*
+The name of the shared Secret holding app credentials + tokens.
+*/}}
+{{- define "tdt.secretName" -}}
+{{- default (printf "%s-secrets" .Release.Name) .Values.existingSecret -}}
+{{- end -}}
+
+{{/*
+Image reference helper: (dict "img" .Values.api.image "root" $)
+Renders "<repository>:<tag>", defaulting the tag to the chart's global tag.
+*/}}
+{{- define "tdt.image" -}}
+{{- $img := .img -}}
+{{- $tag := default .root.Values.global.imageTag $img.tag -}}
+{{- printf "%s:%s" $img.repository $tag -}}
+{{- end -}}

--- a/deploy/helm/terraducktel/templates/api.yaml
+++ b/deploy/helm/terraducktel/templates/api.yaml
@@ -1,0 +1,111 @@
+{{- if .Values.api.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  labels:
+    {{- include "tdt.labels" . | nindent 4 }}
+    app: api
+spec:
+  ports:
+    - name: http
+      port: {{ .Values.api.service.port }}
+      targetPort: 8000
+  selector:
+    app: api
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+  labels:
+    {{- include "tdt.labels" . | nindent 4 }}
+    app: api
+spec:
+  replicas: {{ .Values.api.replicas }}
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        {{- include "tdt.labels" . | nindent 8 }}
+        app: api
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999          # `terraducktel` user baked into the image
+        runAsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+      {{- if .Values.postgres.enabled }}
+      # Block boot until Postgres accepts connections so the entrypoint's
+      # `alembic upgrade head` doesn't hit connection-refused and crash-loop.
+      initContainers:
+        - name: wait-for-postgres
+          image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h postgres -p 5432 -U {{ .Values.postgres.auth.username }}; do
+                echo "waiting for postgres..."; sleep 2
+              done
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+      {{- end }}
+      containers:
+        - name: api
+          image: {{ include "tdt.image" (dict "img" .Values.api.image "root" $) }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8000
+          envFrom:
+            - secretRef:
+                name: {{ include "tdt.secretName" . }}
+          env:
+            - name: TDT_RUN_MIGRATIONS
+              value: {{ .Values.api.runMigrationsOnBoot | toString | quote }}
+            {{- range $k, $v := .Values.api.env }}
+            - name: {{ $k }}
+              value: {{ $v | quote }}
+            {{- end }}
+            {{- with .Values.api.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          # Migrations run before uvicorn binds, so allow generous startup time.
+          startupProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 5
+            failureThreshold: 40      # ~200s for migrations + boot
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8000
+            periodSeconds: 15
+            timeoutSeconds: 3
+            failureThreshold: 4
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}
+{{- end }}

--- a/deploy/helm/terraducktel/templates/detectors.yaml
+++ b/deploy/helm/terraducktel/templates/detectors.yaml
@@ -1,0 +1,113 @@
+{{- if .Values.driftDetector.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: drift-detector
+  labels:
+    {{- include "tdt.labels" . | nindent 4 }}
+    app: drift-detector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: drift-detector
+  template:
+    metadata:
+      labels:
+        {{- include "tdt.labels" . | nindent 8 }}
+        app: drift-detector
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999          # `appuser` baked into the detector image
+        runAsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: drift-detector
+          image: {{ include "tdt.image" (dict "img" .Values.driftDetector.image "root" $) }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          # Needs TERRADUCKTEL_INTERNAL_TOKEN + TERRADUCKTEL_STATE_TOKEN (secret).
+          envFrom:
+            - secretRef:
+                name: {{ include "tdt.secretName" . }}
+          env:
+            - name: API_URL
+              value: "http://api:8000"
+            - name: DRIFT_INTERVAL_SEC
+              value: {{ .Values.driftDetector.intervalSec | quote }}
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "grep -q detector.py /proc/1/cmdline || exit 1"]
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            {{- toYaml .Values.driftDetector.resources | nindent 12 }}
+{{- end }}
+{{- if .Values.livenessDetector.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: liveness-detector
+  labels:
+    {{- include "tdt.labels" . | nindent 4 }}
+    app: liveness-detector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: liveness-detector
+  template:
+    metadata:
+      labels:
+        {{- include "tdt.labels" . | nindent 8 }}
+        app: liveness-detector
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999          # `appuser` baked into the detector image
+        runAsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: liveness-detector
+          image: {{ include "tdt.image" (dict "img" .Values.livenessDetector.image "root" $) }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          # Needs TERRADUCKTEL_INTERNAL_TOKEN (secret). Does NOT use state token.
+          envFrom:
+            - secretRef:
+                name: {{ include "tdt.secretName" . }}
+          env:
+            - name: API_URL
+              value: "http://api:8000"
+            - name: LIVENESS_INTERVAL_SEC
+              value: {{ .Values.livenessDetector.intervalSec | quote }}
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "grep -q detector.py /proc/1/cmdline || exit 1"]
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            {{- toYaml .Values.livenessDetector.resources | nindent 12 }}
+{{- end }}

--- a/deploy/helm/terraducktel/templates/forgejo.yaml
+++ b/deploy/helm/terraducktel/templates/forgejo.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.forgejo.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: forgejo
+  labels:
+    {{- include "tdt.labels" . | nindent 4 }}
+    app: forgejo
+spec:
+  ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+  selector:
+    app: forgejo
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: forgejo
+  labels:
+    {{- include "tdt.labels" . | nindent 4 }}
+    app: forgejo
+spec:
+  serviceName: forgejo
+  replicas: 1
+  selector:
+    matchLabels:
+      app: forgejo
+  template:
+    metadata:
+      labels:
+        {{- include "tdt.labels" . | nindent 8 }}
+        app: forgejo
+    spec:
+      containers:
+        - name: forgejo
+          image: "{{ .Values.forgejo.image.repository }}:{{ .Values.forgejo.image.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            - name: FORGEJO__database__DB_TYPE
+              value: postgres
+            - name: FORGEJO__database__HOST
+              value: postgres:5432
+            - name: FORGEJO__database__NAME
+              value: forgejo
+            - name: FORGEJO__database__USER
+              value: {{ .Values.postgres.auth.username | quote }}
+            - name: FORGEJO__database__PASSWD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "tdt.secretName" . }}
+                  key: POSTGRES_PASSWORD
+            - name: FORGEJO__server__HTTP_PORT
+              value: "3000"
+          readinessProbe:
+            httpGet:
+              path: /api/healthz
+              port: 3000
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            failureThreshold: 10
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            {{- toYaml .Values.forgejo.resources | nindent 12 }}
+      {{- if not .Values.forgejo.persistence.enabled }}
+      volumes:
+        - name: data
+          emptyDir: {}
+      {{- end }}
+  {{- if .Values.forgejo.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.forgejo.persistence.storageClass }}
+        storageClassName: {{ .Values.forgejo.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.forgejo.persistence.size }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/terraducktel/templates/ingress.yaml
+++ b/deploy/helm/terraducktel/templates/ingress.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: terraducktel
+  labels:
+    {{- include "tdt.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    # All traffic goes to the UI; nginx inside the UI pod proxies /api → api:8000.
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ui
+                port:
+                  number: {{ .Values.ui.service.port }}
+{{- end }}

--- a/deploy/helm/terraducktel/templates/jobs.yaml
+++ b/deploy/helm/terraducktel/templates/jobs.yaml
@@ -1,0 +1,99 @@
+{{- if .Values.migrationJob.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-migrate
+  labels:
+    {{- include "tdt.labels" . | nindent 4 }}
+    app: migrate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        {{- include "tdt.labels" . | nindent 8 }}
+        app: migrate
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999          # api image `terraducktel` user
+        runAsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: migrate
+          image: {{ include "tdt.image" (dict "img" .Values.api.image "root" $) }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          envFrom:
+            - secretRef:
+                name: {{ include "tdt.secretName" . }}
+          command: ["sh", "-c"]
+          args:
+            - |
+              cd /app
+              for i in $(seq 1 40); do
+                if alembic upgrade head; then exit 0; fi
+                echo "[migrate] waiting for DB... ($i)"; sleep 5
+              done
+              echo "[migrate] gave up waiting for DB"; exit 1
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+{{- end }}
+{{- if .Values.seedUsers.enabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-seed-users
+  labels:
+    {{- include "tdt.labels" . | nindent 4 }}
+    app: seed-users
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 6
+  template:
+    metadata:
+      labels:
+        {{- include "tdt.labels" . | nindent 8 }}
+        app: seed-users
+    spec:
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999          # api image `terraducktel` user
+        runAsGroup: 999
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: seed-users
+          image: {{ include "tdt.image" (dict "img" .Values.api.image "root" $) }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          # No SEED_RANDOM_PASSWORDS → creates the well-known dev password
+          # `password123` for admin@/operator@/viewer@test.com. DEV ONLY.
+          envFrom:
+            - secretRef:
+                name: {{ include "tdt.secretName" . }}
+          command: ["sh", "-c"]
+          args:
+            - |
+              cd /app
+              for i in $(seq 1 40); do
+                if alembic upgrade head; then break; fi
+                echo "[seed] waiting for DB... ($i)"; sleep 5
+              done
+              python scripts/seed_dev_users.py
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+{{- end }}

--- a/deploy/helm/terraducktel/templates/localstack.yaml
+++ b/deploy/helm/terraducktel/templates/localstack.yaml
@@ -1,0 +1,100 @@
+{{- if .Values.localstack.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: localstack
+  labels:
+    {{- include "tdt.labels" . | nindent 4 }}
+    app: localstack
+spec:
+  ports:
+    - name: edge
+      port: 4566
+      targetPort: 4566
+  selector:
+    app: localstack
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: localstack
+  labels:
+    {{- include "tdt.labels" . | nindent 4 }}
+    app: localstack
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: localstack
+  template:
+    metadata:
+      labels:
+        {{- include "tdt.labels" . | nindent 8 }}
+        app: localstack
+    spec:
+      containers:
+        - name: localstack
+          image: "{{ .Values.localstack.image.repository }}:{{ .Values.localstack.image.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+            - name: edge
+              containerPort: 4566
+          env:
+            - name: SERVICES
+              value: "s3"
+            - name: DEFAULT_REGION
+              value: "us-east-1"
+            {{- if .Values.localstack.persistence.enabled }}
+            - name: PERSISTENCE
+              value: "1"
+            {{- end }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/localstack
+          readinessProbe:
+            httpGet:
+              path: /_localstack/health
+              port: 4566
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 12
+          livenessProbe:
+            httpGet:
+              path: /_localstack/health
+              port: 4566
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 6
+          resources:
+            {{- toYaml .Values.localstack.resources | nindent 12 }}
+      volumes:
+        - name: data
+          {{- if .Values.localstack.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: localstack-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+{{- if .Values.localstack.persistence.enabled }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: localstack-data
+  labels:
+    {{- include "tdt.labels" . | nindent 4 }}
+    app: localstack
+spec:
+  accessModes: ["ReadWriteOnce"]
+  {{- if .Values.localstack.persistence.storageClass }}
+  storageClassName: {{ .Values.localstack.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.localstack.persistence.size }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/terraducktel/templates/pg-backup.yaml
+++ b/deploy/helm/terraducktel/templates/pg-backup.yaml
@@ -1,0 +1,73 @@
+{{- if .Values.pgBackup.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pg-backups
+  labels:
+    {{- include "tdt.labels" . | nindent 4 }}
+    app: pg-backup
+spec:
+  accessModes: ["ReadWriteOnce"]
+  {{- if .Values.pgBackup.persistence.storageClass }}
+  storageClassName: {{ .Values.pgBackup.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.pgBackup.persistence.size }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pg-backup
+  labels:
+    {{- include "tdt.labels" . | nindent 4 }}
+    app: pg-backup
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: pg-backup
+  template:
+    metadata:
+      labels:
+        {{- include "tdt.labels" . | nindent 8 }}
+        app: pg-backup
+    spec:
+      # The entrypoint starts as root to chown the backup dir, then drops to the
+      # `postgres` user (su-exec). Do NOT set runAsNonRoot here.
+      containers:
+        - name: pg-backup
+          image: {{ include "tdt.image" (dict "img" .Values.pgBackup.image "root" $) }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            - name: PG_HOST
+              value: postgres
+            - name: PG_PORT
+              value: "5432"
+            - name: PG_USER
+              value: {{ .Values.postgres.auth.username | quote }}
+            - name: PG_DB
+              value: {{ .Values.postgres.auth.database | quote }}
+            - name: PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "tdt.secretName" . }}
+                  key: POSTGRES_PASSWORD
+            - name: BACKUP_DIR
+              value: /backups
+            - name: BACKUP_INTERVAL_SECONDS
+              value: {{ .Values.pgBackup.intervalSeconds | quote }}
+            - name: BACKUP_RETENTION_DAYS
+              value: {{ .Values.pgBackup.retentionDays | quote }}
+          volumeMounts:
+            - name: backups
+              mountPath: /backups
+          resources:
+            {{- toYaml .Values.pgBackup.resources | nindent 12 }}
+      volumes:
+        - name: backups
+          persistentVolumeClaim:
+            claimName: pg-backups
+{{- end }}

--- a/deploy/helm/terraducktel/templates/postgres.yaml
+++ b/deploy/helm/terraducktel/templates/postgres.yaml
@@ -1,0 +1,121 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: postgres-init
+  labels:
+    {{- include "tdt.labels" . | nindent 4 }}
+    app: postgres
+data:
+  # Creates the extra `forgejo` database on first init (empty data dir only),
+  # mirroring scripts/init-db.sh from the compose stack.
+  init-db.sh: |
+    #!/bin/bash
+    set -e
+    echo "==> init-db.sh: creating forgejo database"
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+        CREATE DATABASE forgejo OWNER $POSTGRES_USER;
+        GRANT ALL PRIVILEGES ON DATABASE forgejo TO $POSTGRES_USER;
+    EOSQL
+    echo "==> init-db.sh: forgejo database created"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    {{- include "tdt.labels" . | nindent 4 }}
+    app: postgres
+spec:
+  # Headless is not required; a normal ClusterIP gives the stable `postgres` DNS.
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432
+  selector:
+    app: postgres
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  labels:
+    {{- include "tdt.labels" . | nindent 4 }}
+    app: postgres
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        {{- include "tdt.labels" . | nindent 8 }}
+        app: postgres
+    spec:
+      securityContext:
+        fsGroup: 999          # postgres user in the alpine image
+      containers:
+        - name: postgres
+          image: "{{ .Values.postgres.image.repository }}:{{ .Values.postgres.image.tag }}"
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+            - name: postgres
+              containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.postgres.auth.database | quote }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgres.auth.username | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "tdt.secretName" . }}
+                  key: POSTGRES_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+            - name: init
+              mountPath: /docker-entrypoint-initdb.d
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U {{ .Values.postgres.auth.username }} -d {{ .Values.postgres.auth.database }}"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U {{ .Values.postgres.auth.username }} -d {{ .Values.postgres.auth.database }}"]
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            timeoutSeconds: 5
+            failureThreshold: 5
+          resources:
+            {{- toYaml .Values.postgres.resources | nindent 12 }}
+      volumes:
+        - name: init
+          configMap:
+            name: postgres-init
+            defaultMode: 0555
+        {{- if not .Values.postgres.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
+  {{- if .Values.postgres.persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- if .Values.postgres.persistence.storageClass }}
+        storageClassName: {{ .Values.postgres.persistence.storageClass | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgres.persistence.size }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/terraducktel/templates/secret.yaml
+++ b/deploy/helm/terraducktel/templates/secret.yaml
@@ -1,0 +1,20 @@
+{{- if not .Values.existingSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "tdt.secretName" . }}
+  labels:
+    {{- include "tdt.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  # Only this one hard-crashes the API on boot if missing.
+  CREDENTIAL_ENCRYPTION_KEY: {{ .Values.secrets.credentialEncryptionKey | quote }}
+  JWT_SECRET_KEY: {{ .Values.secrets.jwtSecretKey | quote }}
+  # Async driver for the app; alembic rewrites it to psycopg2 for migrations.
+  DATABASE_URL: {{ printf "postgresql+asyncpg://%s:%s@postgres:5432/%s" .Values.postgres.auth.username .Values.postgres.auth.password .Values.postgres.auth.database | quote }}
+  TERRADUCKTEL_STATE_TOKEN: {{ .Values.secrets.stateToken | quote }}
+  TERRADUCKTEL_INTERNAL_TOKEN: {{ .Values.secrets.internalToken | quote }}
+  # Consumed by the postgres and pg-backup pods.
+  POSTGRES_PASSWORD: {{ .Values.postgres.auth.password | quote }}
+  PG_PASSWORD: {{ .Values.postgres.auth.password | quote }}
+{{- end }}

--- a/deploy/helm/terraducktel/templates/ui.yaml
+++ b/deploy/helm/terraducktel/templates/ui.yaml
@@ -1,0 +1,147 @@
+{{- if .Values.ui.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ui-nginx
+  labels:
+    {{- include "tdt.labels" . | nindent 4 }}
+    app: ui
+data:
+  # Kubernetes-adapted nginx config. Differences vs the baked-in compose config:
+  #   * Dropped `resolver 127.0.0.11` (that is Docker's embedded DNS and does
+  #     not exist in a pod). We use a STATIC `proxy_pass http://api:8000` which
+  #     nginx resolves via the pod's /etc/resolv.conf (CoreDNS) at startup. The
+  #     `api` Service ClusterIP is stable for the Service's lifetime, so caching
+  #     it at boot is correct (no need to re-resolve per request).
+  # Everything else (CSP + security headers, /healthz, SPA fallback, asset
+  # caching) matches services/ui/nginx.conf.
+  default.conf: |
+    server {
+        listen 8080;
+        server_name _;
+
+        root /usr/share/nginx/html;
+        index index.html;
+
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com data:; img-src 'self' data: blob:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
+        add_header Strict-Transport-Security "max-age=15768000; includeSubDomains" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+
+        # Proxy API (browser uses same origin: /api -> FastAPI Service `api`).
+        location /api {
+            proxy_pass http://api:8000;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        # SPA fallback
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+
+        # Health check endpoint
+        location /healthz {
+            return 200 'ok';
+            add_header Content-Type text/plain;
+        }
+
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+            add_header X-Content-Type-Options "nosniff" always;
+            add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        }
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ui
+  labels:
+    {{- include "tdt.labels" . | nindent 4 }}
+    app: ui
+spec:
+  type: {{ .Values.ui.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.ui.service.port }}
+      targetPort: 8080
+      {{- if and (eq .Values.ui.service.type "NodePort") .Values.ui.service.nodePort }}
+      nodePort: {{ .Values.ui.service.nodePort }}
+      {{- end }}
+  selector:
+    app: ui
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ui
+  labels:
+    {{- include "tdt.labels" . | nindent 4 }}
+    app: ui
+spec:
+  replicas: {{ .Values.ui.replicas }}
+  selector:
+    matchLabels:
+      app: ui
+  template:
+    metadata:
+      labels:
+        {{- include "tdt.labels" . | nindent 8 }}
+        app: ui
+      annotations:
+        # Roll the UI pods when the nginx config changes.
+        checksum/nginx-config: {{ .Values.ui | toYaml | sha256sum }}
+    spec:
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 100          # `appuser` baked into the nginx image
+        runAsGroup: 102
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: ui
+          image: {{ include "tdt.image" (dict "img" .Values.ui.image "root" $) }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 15
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          resources:
+            {{- toYaml .Values.ui.resources | nindent 12 }}
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: ui-nginx
+            items:
+              - key: default.conf
+                path: default.conf
+{{- end }}

--- a/deploy/helm/terraducktel/values.yaml
+++ b/deploy/helm/terraducktel/values.yaml
@@ -1,0 +1,181 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# Terraducktel Helm chart — default values (tuned for a kind/dev cluster).
+#
+# The application has HARD-CODED service DNS names it expects on the same
+# network: the API reaches Postgres at `postgres:5432` and LocalStack at
+# `localstack:4566`; the UI's nginx proxies `/api` → `http://api:8000`; the
+# drift/liveness detectors default to `http://api:8000`; Forgejo reaches
+# `postgres:5432`. For that reason the Services below are given the BARE names
+# `api`, `postgres`, `localstack`, `forgejo` (not release-prefixed). Deploy the
+# release into its own namespace so those names never collide.
+# ─────────────────────────────────────────────────────────────────────────────
+
+global:
+  # Default image tag applied to every TDT image unless overridden per-service.
+  imageTag: latest
+  # IfNotPresent uses images pre-loaded into the node (e.g. `kind load
+  # docker-image`) and never tries to pull a `latest` tag from a registry.
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+
+# ── Secrets ──────────────────────────────────────────────────────────────────
+# DEV DEFAULTS ONLY. Change every value for anything beyond a local cluster.
+# Set `existingSecret` to the name of a pre-created Secret to supply these out
+# of band instead (it must contain the same keys the chart's Secret would).
+existingSecret: ""
+secrets:
+  # Only CREDENTIAL_ENCRYPTION_KEY is required at API boot; the rest are needed
+  # for a functioning deployment (auth, state backend, internal API).
+  credentialEncryptionKey: "local-dev-encryption-key-32bytes!!"
+  jwtSecretKey: "local-dev-jwt-secret-key-at-least-32-bytes-long!!"
+  # These two MUST differ. Generate with `openssl rand -hex 32` for real use.
+  stateToken: "dev-state-token-0000000000000000000000000000aa"
+  internalToken: "dev-internal-token-11111111111111111111111bb"
+
+# ── Postgres ─────────────────────────────────────────────────────────────────
+postgres:
+  enabled: true
+  image:
+    repository: postgres
+    tag: "16-alpine"
+  auth:
+    username: terraducktel
+    password: "localdevpassword"   # dev only
+    database: terraducktel
+  # PGDATA points at a sub-directory of the mount so the volume root (which may
+  # contain a lost+found) doesn't break initdb.
+  persistence:
+    enabled: true
+    size: 2Gi
+    storageClass: ""     # "" = cluster default (kind ships `standard`)
+  resources:
+    requests: {cpu: 50m, memory: 128Mi}
+    limits: {memory: 512Mi}
+
+# ── LocalStack (dev S3 for Terraform state) ──────────────────────────────────
+# In prod you use real AWS S3 (per-account buckets); LocalStack is the dev
+# stand-in. The API hard-codes the endpoint `http://localstack:4566` when
+# S3_USE_LOCALSTACK=true, so the Service name must be `localstack`.
+localstack:
+  enabled: true
+  image:
+    repository: localstack/localstack
+    tag: "3"
+  persistence:
+    enabled: false       # ephemeral is fine for dev
+    size: 1Gi
+    storageClass: ""
+  resources:
+    requests: {cpu: 50m, memory: 256Mi}
+    limits: {memory: 1Gi}
+
+# ── API (FastAPI orchestrator) ───────────────────────────────────────────────
+api:
+  enabled: true
+  replicas: 1
+  image:
+    repository: terraducktel-api
+    tag: ""              # "" → global.imageTag
+  service:
+    port: 8000
+  # Runs `alembic upgrade head` on boot (idempotent). Set false to run
+  # migrations only via the dedicated migration Job below.
+  runMigrationsOnBoot: true
+  env:
+    S3_USE_LOCALSTACK: "true"
+    S3_STATE_BUCKET: "terraducktel-state"
+    # No Docker socket in-cluster → executor launching is disabled. The core
+    # platform (auth, workspaces, drift surfacing, state backend) is unaffected.
+    # See NOTES.txt for how to run executors out-of-cluster (EXECUTOR_RUNTIME=ecs).
+    EXECUTOR_ENABLED: "false"
+  extraEnv: []           # list of {name, value} for ad-hoc overrides
+  resources:
+    requests: {cpu: 100m, memory: 256Mi}
+    limits: {memory: 768Mi}
+
+# ── UI (React SPA served by nginx, proxies /api → api:8000) ──────────────────
+ui:
+  enabled: true
+  replicas: 1
+  image:
+    repository: terraducktel-ui
+    tag: ""
+  service:
+    type: ClusterIP      # set NodePort for direct kind access, or use Ingress
+    port: 80             # Service port; container listens on 8080
+    nodePort: ""         # only used when type=NodePort
+  resources:
+    requests: {cpu: 20m, memory: 32Mi}
+    limits: {memory: 128Mi}
+
+# ── Drift detector (periodic; talks to the API over HTTP) ────────────────────
+driftDetector:
+  enabled: true
+  image:
+    repository: terraducktel-drift-detector
+    tag: ""
+  intervalSec: "300"
+  resources:
+    requests: {cpu: 20m, memory: 64Mi}
+    limits: {memory: 256Mi}
+
+# ── Liveness detector (periodic; needs egress to api.github.com) ─────────────
+livenessDetector:
+  enabled: true
+  image:
+    repository: terraducktel-liveness-detector
+    tag: ""
+  intervalSec: "300"
+  resources:
+    requests: {cpu: 10m, memory: 32Mi}
+    limits: {memory: 128Mi}
+
+# ── Seed dev users (post-install Helm hook) ──────────────────────────────────
+# Creates admin@test.com / operator@test.com / viewer@test.com with the
+# well-known dev password `password123`. DEV ONLY — leave disabled in prod.
+seedUsers:
+  enabled: true
+
+# ── Standalone migration Job (optional) ──────────────────────────────────────
+# Only needed if api.runMigrationsOnBoot=false. Runs as a pre-install/upgrade
+# hook. Off by default because the API runs migrations on boot.
+migrationJob:
+  enabled: false
+
+# ── Forgejo (self-hosted Git; optional) ──────────────────────────────────────
+forgejo:
+  enabled: false
+  image:
+    repository: codeberg.org/forgejo/forgejo
+    tag: "7"
+  persistence:
+    enabled: true
+    size: 2Gi
+    storageClass: ""
+  resources:
+    requests: {cpu: 50m, memory: 128Mi}
+    limits: {memory: 512Mi}
+
+# ── Postgres logical backup sidecar (optional) ───────────────────────────────
+pgBackup:
+  enabled: false
+  image:
+    repository: terraducktel-pg-backup
+    tag: ""
+  intervalSeconds: "21600"
+  retentionDays: "7"
+  persistence:
+    enabled: true
+    size: 2Gi
+    storageClass: ""
+  resources:
+    requests: {cpu: 10m, memory: 32Mi}
+    limits: {memory: 128Mi}
+
+# ── Ingress (optional; routes to the UI which proxies /api itself) ───────────
+ingress:
+  enabled: false
+  className: ""
+  host: terraducktel.local
+  annotations: {}
+  tls: []


### PR DESCRIPTION
## What

Adds a Helm chart at `deploy/helm/terraducktel/` for deploying Terraducktel to Kubernetes — the k8s counterpart to the existing docker-compose and `deploy/aws-ecs/` paths.

Packages the full stack:

- **Core (on by default):** `postgres` (StatefulSet + init-db), `localstack` (dev S3), `api`, `ui`, `drift-detector`, `liveness-detector`
- **Optional (off by default):** `forgejo`, `pg-backup`, `ingress`, and a standalone migration Job
- **Post-install hook:** seeds the dev users (`admin@/operator@/viewer@test.com`), gated by `seedUsers.enabled`

## Notable k8s adaptations

- **Bare Service names** (`api`, `postgres`, `localstack`, `forgejo`) because the app hard-codes those DNS names (`localstack:4566`, UI nginx → `api:8000`, detectors → `api:8000`). Deploy into a dedicated namespace.
- **UI nginx** config is overridden via ConfigMap — the baked image uses Docker's embedded resolver (`127.0.0.11`), which doesn't exist in a pod; the chart uses a static CoreDNS-resolved `proxy_pass`.
- **Non-root** everywhere with pinned numeric UIDs (kubelet can't verify named users), `runAsNonRoot`, dropped capabilities, `RuntimeDefault` seccomp.
- **`wait-for-postgres` initContainer** on the API so boot migrations never crash-loop.
- **Executor launching is disabled** (`EXECUTOR_ENABLED=false`) — the compose pattern spawns sibling containers via the host Docker socket, which pods lack. The core platform is unaffected; see `NOTES.txt`.

## Testing

Deployed end-to-end on a local `kind` cluster:

- All core pods `1/1 Running`, 0 restarts after a clean rollout
- API `/health` 200; migrations auto-applied on boot
- Full login flow through the UI `/api` proxy with the seeded admin (UI → API → Postgres → JWT); wrong password → 401
- Authenticated + internal-token endpoints return 200; unauthenticated → 401
- `helm lint` clean; renders and client-side-validates with all optional components enabled

## Usage

```bash
helm install tdt deploy/helm/terraducktel -n terraducktel --create-namespace
kubectl -n terraducktel port-forward svc/ui 8080:80   # http://localhost:8080
```

> Secrets in `values.yaml` are dev defaults — override them (or use `existingSecret`) for anything beyond local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
