### PR TITLE
fix(inventory): match arn-less resource types so NAT gateways stop showing unmanaged

### DIFF
--- a/services/api/app/services/inventory_service.py
+++ b/services/api/app/services/inventory_service.py
@@ -25,6 +25,25 @@ from app.models.inventory_ignore_rule import InventoryIgnoreRule
 logger = logging.getLogger(__name__)
 
 
+def _arn_id_candidates(arn: str) -> set[str]:
+    """Terraform-`id`-shaped forms of an ARN's resource part.
+
+    Twin of `_arn_id_candidates` in services/drift-detector/detector.py (the two
+    services share no package; keep them in step). Needed because resource types
+    with no `arn` in the provider schema — `aws_nat_gateway`,
+    `aws_vpc_peering_connection` — are codified under their bare id (`nat-0ab…`),
+    while a live hit for the same resource arrives as a full ARN. Comparing the
+    two as strings never matches, so they looked `unmanaged`.
+    """
+    if not arn.startswith("arn:"):
+        return set()
+    parts = arn.split(":", 5)
+    if len(parts) < 6 or not parts[5]:
+        return set()
+    resource = parts[5]
+    return {c for c in (resource, resource.rsplit("/", 1)[-1], resource.rsplit(":", 1)[-1]) if c}
+
+
 def _matches_any_rule(asset_id: str, asset_type: str, rules) -> bool:
     """True if the asset matches any ignore rule (arn_glob / asset_type)."""
     for r in rules:
@@ -125,6 +144,10 @@ async def refresh_workspace_assets(db: AsyncSession, workspace, assets) -> None:
             # cause was non-unique provider ids like random_password's "none",
             # now also filtered at the detector.)
             continue
+        if not is_managed and managed_elsewhere & _arn_id_candidates(a.asset_id):
+            # Same live resource as an arn-less asset a sibling workspace already
+            # codified under its bare id — not rogue, just unmatchable by string.
+            continue
         seen.add(a.asset_id)
         to_insert.append(a)
 
@@ -138,6 +161,33 @@ async def refresh_workspace_assets(db: AsyncSession, workspace, assets) -> None:
                 CloudAsset.asset_id.in_(collide_ids),
             )
         )
+
+    # 6. Sweep account-scoped rows that are the *same live resource* as an
+    #    arn-less asset this payload codifies (their asset_id is the full ARN,
+    #    the codified row's is the bare id). Neither step 2 (only prunes accounts
+    #    still reporting a non-managed asset) nor step 5 (exact asset_id) catches
+    #    those, so a false positive fixed upstream would otherwise never clear.
+    bare_ids = {
+        a.asset_id for a in to_insert
+        if a.iac_status in MANAGED_STATES and not a.asset_id.startswith("arn:")
+    }
+    bare_accounts = {
+        a.account_id for a in to_insert if a.asset_id in bare_ids and a.account_id
+    }
+    if bare_ids and bare_accounts:
+        stale = (
+            await db.execute(
+                select(CloudAsset).where(
+                    CloudAsset.business_unit_id == bu,
+                    CloudAsset.workspace_id.is_(None),
+                    CloudAsset.iac_status.not_in(MANAGED_STATES),
+                    CloudAsset.account_id.in_(bare_accounts),
+                )
+            )
+        ).scalars().all()
+        for row in stale:
+            if bare_ids & _arn_id_candidates(row.asset_id):
+                await db.delete(row)
 
     for a in to_insert:
         is_managed = a.iac_status in MANAGED_STATES

--- a/services/api/tests/test_inventory.py
+++ b/services/api/tests/test_inventory.py
@@ -283,3 +283,80 @@ async def test_duplicate_managed_asset_id_across_workspaces_does_not_500(
             select(func.count()).select_from(CloudAsset).where(CloudAsset.asset_id == "none")
         )).scalar()
     assert n == 1
+
+
+async def test_arnless_asset_codified_by_sibling_is_not_flagged_unmanaged(
+    auth_client, admin_token, workspace_id
+):
+    """A NAT gateway codified by one workspace under its bare id (`nat-…`, since
+    the AWS provider exposes no `arn` for the type) must not be re-reported as
+    `unmanaged` by a sibling workspace that only sees its live ARN.
+
+    Regression for an Inventory dashboard false positive: the cross-workspace
+    dedup compared ARN-vs-id as strings, so these could never match.
+    """
+    hdr = {"Authorization": f"Bearer {admin_token}"}
+    ws2 = await auth_client.post(
+        "/api/v1/workspaces",
+        json={"name": "inv-ws-arnless", "environment": "dev",
+              "aws_account_id": "123456789012", "region": "us-east-1",
+              "tf_working_dir": "envs/inv-ws-arnless"},
+        headers=hdr,
+    )
+    assert ws2.status_code == 201, ws2.text
+    ws2_id = ws2.json()["id"]
+
+    # Workspace 1 codifies it — tfstate has no arn, so asset_id is the bare id.
+    await _post_assets(auth_client, admin_token, workspace_id, assets=[
+        {"asset_id": "nat-0a1b2c3d4e5f67890", "address": "module.vpc.aws_nat_gateway.a",
+         "asset_type": "aws_nat_gateway", "provider": "aws", "region": "us-east-1",
+         "account_id": "444444444444", "iac_status": "codified"},
+    ])
+    # Workspace 2's live scan sees the same resource as a full ARN.
+    await _post_assets(auth_client, admin_token, ws2_id, assets=[
+        {"asset_id": "arn:aws:ec2:us-east-1:444444444444:natgateway/nat-0a1b2c3d4e5f67890",
+         "address": "", "asset_type": "ec2", "provider": "aws", "region": "us-east-1",
+         "account_id": "444444444444", "iac_status": "unmanaged",
+         "drift_summary": "live resource not present in tfstate"},
+    ])
+
+    s = (await auth_client.get("/api/v1/inventory/summary", headers=hdr)).json()
+    assert s["counts"].get("unmanaged", 0) == 0
+    assert s["counts"]["codified"] == 1
+
+
+async def test_stale_arnless_unmanaged_row_is_swept_once_codified(
+    auth_client, admin_token, workspace_id
+):
+    """A false-positive `unmanaged` row left over from before the arn-less match
+    fix must clear on the next scan.
+
+    It's account-scoped (workspace_id NULL) and keyed by full ARN, so the
+    per-workspace delete, the account prune (no non-managed asset left to name
+    the account) and the exact-asset_id collision delete all miss it.
+    """
+    hdr = {"Authorization": f"Bearer {admin_token}"}
+    arn = "arn:aws:ec2:us-east-1:444444444444:natgateway/nat-0a1b2c3d4e5f67890"
+
+    # Pre-fix scan: reported unmanaged.
+    await _post_assets(auth_client, admin_token, workspace_id, assets=[
+        {"asset_id": arn, "address": "", "asset_type": "ec2", "provider": "aws",
+         "region": "us-east-1", "account_id": "444444444444", "iac_status": "unmanaged",
+         "drift_summary": "live resource not present in tfstate"},
+    ])
+    assert (await auth_client.get(
+        "/api/v1/inventory/summary", headers=hdr)).json()["counts"]["unmanaged"] == 1
+
+    # Post-fix scan: the same resource now matches state, codified under its
+    # bare id, and reports no unmanaged asset at all for the account.
+    await _post_assets(auth_client, admin_token, workspace_id, assets=[
+        {"asset_id": "nat-0a1b2c3d4e5f67890", "address": "module.vpc.aws_nat_gateway.a",
+         "asset_type": "aws_nat_gateway", "provider": "aws", "region": "us-east-1",
+         "account_id": "444444444444", "iac_status": "codified"},
+    ])
+
+    s = (await auth_client.get("/api/v1/inventory/summary", headers=hdr)).json()
+    assert s["counts"].get("unmanaged", 0) == 0
+    assert s["counts"]["codified"] == 1
+    rows = (await auth_client.get("/api/v1/inventory/assets", headers=hdr)).json()
+    assert [r["asset_id"] for r in rows["items"]] == ["nat-0a1b2c3d4e5f67890"]

--- a/services/drift-detector/detector.py
+++ b/services/drift-detector/detector.py
@@ -44,16 +44,50 @@ def _arn_service(arn: str) -> str:
     return parts[2] if len(parts) > 2 else ""
 
 
+def _arn_id_candidates(arn: str) -> set[str]:
+    """Terraform-`id`-shaped forms of a live ARN's resource part.
+
+    The live scan only ever yields ARNs, but several AWS resource types have no
+    `arn` attribute in the provider schema at all — `aws_nat_gateway` and
+    `aws_vpc_peering_connection` are the common ones — so their tfstate entry
+    contributes only the bare id (`nat-0ab…`, `pcx-09c…`). Comparing an ARN
+    against that can never match, which made every NAT gateway and peering
+    connection report as `unmanaged` no matter how well codified it was.
+
+    We can't build the missing ARN, so we go the other way: reduce the ARN to
+    the id forms Terraform actually stores and look those up instead.
+
+        arn:aws:ec2:us-east-1:123:natgateway/nat-0ab   → {natgateway/nat-0ab, nat-0ab}
+        arn:aws:logs:us-east-1:123:log-group:/app/api  → {log-group:/app/api, /app/api, api}
+        arn:aws:s3:::my-bucket                         → {my-bucket}
+
+    Returns an empty set for anything that isn't an ARN.
+    """
+    if not arn.startswith("arn:"):
+        return set()
+    parts = arn.split(":", 5)
+    if len(parts) < 6 or not parts[5]:
+        return set()
+    resource = parts[5]
+    # Both separators AWS uses between resource type and resource id, split from
+    # the right so ids that themselves contain `/` or `:` survive one level.
+    return {c for c in (resource, resource.rsplit("/", 1)[-1], resource.rsplit(":", 1)[-1]) if c}
+
+
 # ─── tfstate parsing (managed resources) ─────────────────────────────────────
 
 
-def _managed_from_tfstate(state: dict, region: str, account_id: str) -> tuple[list, set]:
+def _managed_from_tfstate(state: dict, region: str, account_id: str) -> tuple[list, set, set]:
     """Parse a raw Terraform state document into codified assets.
 
-    Returns (assets, managed_ids). `managed_ids` is the set of ARNs/ids used to
-    diff against the live scan. Only `mode == "managed"` resources count; data
-    sources are skipped. Handles state v4 (flat `resources[]` with a `module`
-    field on nested-module resources).
+    Returns (assets, managed_ids, arnless_ids). `managed_ids` is the set of
+    ARNs/ids used to diff against the live scan. `arnless_ids` holds the ids of
+    resources whose provider schema exposes no `arn` at all — the live scan's
+    ARN has to be reduced to an id form (`_arn_id_candidates`) to match those,
+    and keeping them separate confines that fuzzier lookup to the types that
+    need it. Only `mode == "managed"` resources count; data sources are skipped.
+    Handles state v4 (flat `resources[]` with a `module` field on nested-module
+    resources).
 
     Resources from non-cloud "logical" providers (random/null/tls/time/…) are
     skipped: they aren't cloud assets, and several carry non-unique sentinel ids
@@ -64,6 +98,7 @@ def _managed_from_tfstate(state: dict, region: str, account_id: str) -> tuple[li
     """
     assets: list[dict] = []
     managed_ids: set[str] = set()
+    arnless_ids: set[str] = set()
 
     for res in state.get("resources", []) or []:
         if res.get("mode") != "managed":
@@ -93,6 +128,8 @@ def _managed_from_tfstate(state: dict, region: str, account_id: str) -> tuple[li
                 managed_ids.add(arn)
             if rid:
                 managed_ids.add(rid)
+                if not arn:
+                    arnless_ids.add(rid)
 
             address = ".".join(p for p in [module, f"{rtype}.{rname}"] if p)
             idx = inst.get("index_key")
@@ -112,7 +149,7 @@ def _managed_from_tfstate(state: dict, region: str, account_id: str) -> tuple[li
                 }
             )
 
-    return assets, managed_ids
+    return assets, managed_ids, arnless_ids
 
 
 # ─── AWS live scan ───────────────────────────────────────────────────────────
@@ -211,14 +248,19 @@ def _analyze_workspace(workspace: dict, creds: dict, state: dict, live: list) ->
     region = workspace.get("region", "us-east-1")
     account_id = (creds or {}).get("account_id", "") or workspace.get("aws_account_id", "")
 
-    managed_assets, managed_ids = _managed_from_tfstate(state, region, account_id)
+    managed_assets, managed_ids, arnless_ids = _managed_from_tfstate(state, region, account_id)
 
     unmanaged_resources: list[dict] = []
     extra_assets: list[dict] = []
     unmanaged = service_managed = 0
     for item in live:
         arn = item.get("arn") if isinstance(item, dict) else item
-        if not arn or arn in managed_ids:
+        if not arn:
+            continue
+        # Exact ARN first; fall back to id-shaped forms for the types the AWS
+        # provider gives no `arn` (NAT gateways, VPC peering connections, …),
+        # whose state entry is a bare id and so can never match an ARN.
+        if arn in managed_ids or (arnless_ids and arnless_ids & _arn_id_candidates(arn)):
             continue
         owner = _service_owner(item.get("tags", {})) if isinstance(item, dict) else None
         if owner:

--- a/services/drift-detector/test_detector.py
+++ b/services/drift-detector/test_detector.py
@@ -18,6 +18,29 @@ def test_arn_service():
     assert detector._arn_service("not-an-arn") == ""
 
 
+# ─── _arn_id_candidates ──────────────────────────────────────────────────────
+
+
+def test_arn_id_candidates_strips_resource_type_prefix():
+    """The arn-less types: their tfstate id is the bare `nat-…`/`pcx-…`, so it
+    must fall out of the live ARN for the diff to match."""
+    assert "nat-0a1b2c3d4e5f67890" in detector._arn_id_candidates(
+        "arn:aws:ec2:us-east-1:444444444444:natgateway/nat-0a1b2c3d4e5f67890")
+    assert "pcx-0123456789abcdef0" in detector._arn_id_candidates(
+        "arn:aws:ec2:us-east-1:444444444444:vpc-peering-connection/pcx-0123456789abcdef0")
+    # `:`-separated resource type, and an id that itself contains `/`
+    cands = detector._arn_id_candidates("arn:aws:logs:us-east-1:123:log-group:/app/api")
+    assert "/app/api" in cands
+    # no resource type at all (S3) — the whole resource part is the id
+    assert detector._arn_id_candidates("arn:aws:s3:::my-bucket") == {"my-bucket"}
+
+
+def test_arn_id_candidates_rejects_non_arns():
+    assert detector._arn_id_candidates("nat-0a1b2c3d4e5f67890") == set()
+    assert detector._arn_id_candidates("arn:aws:s3:::") == set()
+    assert detector._arn_id_candidates("arn:aws:ec2:us-east-1:123") == set()
+
+
 # ─── _managed_from_tfstate ───────────────────────────────────────────────────
 
 
@@ -35,7 +58,7 @@ def test_managed_from_tfstate_classifies_codified():
              "instances": [{"index_key": "a", "attributes": {"arn": "arn:aws:ec2:::i-1", "id": "i-1"}}]},
         ]
     }
-    assets, managed_ids = detector._managed_from_tfstate(state, "us-east-1", "123")
+    assets, managed_ids, arnless_ids = detector._managed_from_tfstate(state, "us-east-1", "123")
     assert len(assets) == 2
     addrs = {a["address"] for a in assets}
     assert "aws_s3_bucket.b" in addrs
@@ -43,11 +66,28 @@ def test_managed_from_tfstate_classifies_codified():
     assert all(a["iac_status"] == "codified" for a in assets)
     assert {a["provider"] for a in assets} == {"aws"}
     assert "arn:aws:s3:::b" in managed_ids and "i-1" in managed_ids
+    assert arnless_ids == set()  # both resources carry an `arn`
+
+
+def test_managed_from_tfstate_collects_arnless_ids():
+    """Resources the AWS provider gives no `arn` land in `arnless_ids` so the
+    live ARN can be matched by id instead."""
+    state = {
+        "resources": [
+            {"mode": "managed", "type": "aws_nat_gateway", "name": "a",
+             "instances": [{"attributes": {"id": "nat-0a1b2c3d4e5f67890"}}]},
+            {"mode": "managed", "type": "aws_vpc", "name": "main",
+             "instances": [{"attributes": {"arn": "arn:aws:ec2:::vpc/vpc-1", "id": "vpc-1"}}]},
+        ]
+    }
+    _, managed_ids, arnless_ids = detector._managed_from_tfstate(state, "us-east-1", "123")
+    assert arnless_ids == {"nat-0a1b2c3d4e5f67890"}
+    assert "vpc-1" in managed_ids and "vpc-1" not in arnless_ids
 
 
 def test_managed_from_tfstate_empty():
-    assets, ids = detector._managed_from_tfstate({}, "us-east-1", "123")
-    assert assets == [] and ids == set()
+    assets, ids, arnless = detector._managed_from_tfstate({}, "us-east-1", "123")
+    assert assets == [] and ids == set() and arnless == set()
 
 
 def test_managed_from_tfstate_skips_random_password_none_id():
@@ -67,7 +107,7 @@ def test_managed_from_tfstate_skips_random_password_none_id():
              "instances": [{"attributes": {"id": "none"}}]},
         ]
     }
-    assets, managed_ids = detector._managed_from_tfstate(state, "us-east-1", "222222222222")
+    assets, managed_ids, _ = detector._managed_from_tfstate(state, "us-east-1", "222222222222")
     # Only the real cloud resource is codified; neither random_password leaks.
     assert [a["asset_type"] for a in assets] == ["aws_db_instance"]
     assert "none" not in managed_ids
@@ -84,7 +124,7 @@ def test_managed_from_tfstate_skips_sentinel_none_id_defensively():
              "instances": [{"attributes": {"id": "none"}}]},
         ]
     }
-    assets, _ = detector._managed_from_tfstate(state, "us-east-1", "123")
+    assets, _, _ = detector._managed_from_tfstate(state, "us-east-1", "123")
     assert assets == []
 
 
@@ -180,6 +220,47 @@ def test_analyze_classifies_codified_unmanaged_and_service_managed():
     sm = [a for a in out["assets"] if a["iac_status"] == "service_managed"][0]
     assert sm["asset_id"] == "arn:aws:ec2:::fleet/f1" and "EKS" in sm["drift_summary"]
     assert "1 codified, 1 unmanaged, 1 service-managed" in out["summary"]
+
+
+def test_analyze_matches_arnless_types_by_id():
+    """Regression: NAT gateways and VPC peering connections have no `arn`
+    attribute in the AWS provider schema at all, so tfstate holds only
+    `nat-…`/`pcx-…` while the tagging API returns a full ARN. They were reported
+    `unmanaged` on every scan despite being fully codified."""
+    acct = "444444444444"
+    state = {"resources": [
+        {"mode": "managed", "type": "aws_nat_gateway", "name": "a",
+         "instances": [{"attributes": {"id": "nat-0a1b2c3d4e5f67890"}},
+                       {"attributes": {"id": "nat-0fedcba9876543210"}}]},
+        {"mode": "managed", "type": "aws_vpc_peering_connection", "name": "peer",
+         "instances": [{"attributes": {"id": "pcx-0123456789abcdef0"}}]},
+    ]}
+    live = [
+        {"arn": f"arn:aws:ec2:us-east-1:{acct}:natgateway/nat-0a1b2c3d4e5f67890", "tags": {}},
+        {"arn": f"arn:aws:ec2:us-east-1:{acct}:natgateway/nat-0fedcba9876543210", "tags": {}},
+        {"arn": f"arn:aws:ec2:us-east-1:{acct}:vpc-peering-connection/pcx-0123456789abcdef0", "tags": {}},
+    ]
+    out = detector._analyze_workspace(
+        {"name": "prod", "region": "us-east-1"}, {"account_id": acct}, state, live)
+    assert out["untracked_count"] == 0
+    assert out["resources"] == []
+    assert {a["iac_status"] for a in out["assets"]} == {"codified"}
+
+
+def test_analyze_still_flags_genuinely_rogue_arnless_resource():
+    """The id-based fallback must not swallow a real unmanaged resource: a NAT
+    gateway absent from state stays `unmanaged`."""
+    state = {"resources": [
+        {"mode": "managed", "type": "aws_nat_gateway", "name": "a",
+         "instances": [{"attributes": {"id": "nat-known"}}]}]}
+    live = [
+        {"arn": "arn:aws:ec2:us-east-1:1:natgateway/nat-known", "tags": {}},
+        {"arn": "arn:aws:ec2:us-east-1:1:natgateway/nat-rogue", "tags": {}},
+    ]
+    out = detector._analyze_workspace(
+        {"name": "x", "region": "us-east-1"}, {"account_id": "1"}, state, live)
+    assert out["untracked_count"] == 1
+    assert out["resources"][0]["address"] == "arn:aws:ec2:us-east-1:1:natgateway/nat-rogue"
 
 
 def test_analyze_empty_state_all_unmanaged():


### PR DESCRIPTION
## The bug

The Inventory dashboard reported NAT gateways and VPC peering connections as **Unmanaged** — "live resource not present in tfstate" — even when they were fully codified and applied by Terraform.

## Root cause

The live scan (Resource Groups Tagging API) only ever yields **ARNs**. `_managed_from_tfstate` collects state identity as both the `arn` and the `id` attribute — but **some AWS resource types have no `arn` attribute in the provider schema at all**. `aws_nat_gateway` and `aws_vpc_peering_connection` are the ones seen in practice, while `aws_vpc` / `aws_subnet` / `aws_internet_gateway` do have one.

So for those types state contributes only a bare id (`nat-0ab…`, `pcx-09c…`), and `arn in managed_ids` could never match. Systemic — every NAT gateway and peering connection in every account was misreported on every scan.

## The fix

Three layers all compared identity as strings:

1. **`detector.py`** — `_managed_from_tfstate` returns a third set, `arnless_ids` (ids of state resources that carried no `arn`). A live ARN is reduced to the id forms Terraform stores (`_arn_id_candidates`: `…:natgateway/nat-0ab` → `nat-0ab`) and checked against *only* that set. Exact-ARN matching still runs first, and confining the fallback to arn-less entries keeps a coincidental name collision from masking genuinely rogue infra.

2. **`inventory_service.py` cross-workspace dedup** — an asset codified by workspace A under its bare id never matched a sibling workspace's live ARN in `managed_elsewhere`. Same normalization, applied to non-managed assets only, so the unique-key collision guard (one duplicate must not sink a whole report) is untouched.

3. **`inventory_service.py` stale-row sweep** — rows already written from the false positive are account-scoped (`workspace_id` NULL) and keyed by full ARN, so the per-workspace delete misses them, the account prune doesn't fire (no non-managed asset left to name the account) and the collision delete matches `asset_id` exactly. Without this the dashboard would keep showing them even once classification was fixed. Now it self-heals on the next scan — no manual DB cleanup.

All three are load-bearing: because each resource is typically codified by a *different* workspace, the detector fix alone clears only the one that workspace owns, and the sibling dedup clears the rest.

## Tests

Each fix has a regression test that **fails without it** (verified by reverting each change individually):

- `test_analyze_matches_arnless_types_by_id` — the end-to-end case; fails `assert 3 == 0` unfixed.
- `test_analyze_still_flags_genuinely_rogue_arnless_resource` — guards the other direction: a NAT gateway absent from state stays `unmanaged`.
- `test_arn_id_candidates_*` — `:`-separated resource types, ids containing `/`, non-ARN input.
- `test_managed_from_tfstate_collects_arnless_ids`
- `test_arnless_asset_codified_by_sibling_is_not_flagged_unmanaged`
- `test_stale_arnless_unmanaged_row_is_swept_once_codified`

`28 passed` (drift-detector) and `511 passed / 4 skipped` (API) locally.

## Note for deployers

Picking this up needs both the **drift-detector** and **api** images rebuilt. Classification corrects on the first scan afterwards; previously-persisted false-positive rows clear on the same pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
