### PR TITLE
fix(ci): auto-cut a release on merge instead of never bumping the version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,17 @@ jobs:
         working-directory: services/ui
         run: npm run test
 
+  release-version:
+    name: Release version logic
+    runs-on: ubuntu-latest
+    # Guards the semver bump the Release workflow derives from conventional
+    # commits. Cheap (throwaway git repos in a temp dir, no deps) and worth it:
+    # a bug here silently mis-versions or skips a release.
+    steps:
+      - uses: actions/checkout@v4
+      - name: next-version regression tests
+        run: bash scripts/test-next-version.sh
+
   security-scan:
     name: Trivy IaC scan (informational)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,24 +1,52 @@
 name: Release
 
-# Cut a GitHub Release from a semver tag. Two ways to trigger:
-#   1. Push a tag:   git tag v0.2.0 && git push origin v0.2.0
-#   2. Actions → "Release" → Run workflow, enter a tag (created from the
-#      selected branch/ref if it doesn't already exist).
+# Cut a GitHub Release. Three ways in:
+#   1. Merge to the default branch → the next version is computed from the
+#      conventional-commit subjects since the last tag and the release is cut
+#      automatically. Nothing releasable since the last tag (docs/chore/ci only)
+#      → no tag, no release, no noise.
+#   2. Push a tag:   git tag v0.2.0 && git push origin v0.2.0
+#   3. Actions → "Release" → Run workflow. Leave `tag` empty to auto-compute
+#      (optionally forcing a level with `bump`), or name an explicit tag.
+#
+# Before this existed, releases only ever happened when a human remembered to
+# push a tag by hand — a merge built, deployed and then sat at the previous
+# version indefinitely.
+#
+# `branches: [main, dev]` covers both the public (`main`) and internal (`dev`)
+# default branches so this file stays byte-identical in both repos; the job
+# guards on `github.event.repository.default_branch` so only the repo's own
+# default branch can auto-release.
 #
 # Uses the built-in `gh` CLI + the job's GITHUB_TOKEN only — no third-party
 # actions in the release path (keeps the supply chain tight). Release notes are
-# auto-generated from merged PRs / commits since the previous tag.
+# auto-generated from merged PRs / commits since the previous tag. The tag is
+# created and the release cut inside the SAME run, deliberately: a tag pushed
+# with GITHUB_TOKEN does not trigger other workflows, so a two-workflow
+# "push tag → react to tag" design would silently never fire.
 on:
   push:
+    branches: [main, dev]
     tags: ["v*.*.*"]
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag, e.g. v0.2.0 (created from the selected ref if missing)"
-        required: true
+        description: "Explicit tag, e.g. v0.2.0. Leave empty to auto-compute from commits."
+        required: false
+      bump:
+        description: "Bump level when auto-computing"
+        required: false
+        default: auto
+        type: choice
+        options: [auto, patch, minor, major]
 
 permissions:
-  contents: write  # create the tag (manual runs) + the release
+  contents: write  # create the tag + the release
+
+# Never cut two releases at once — concurrent runs would race on the tag.
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -27,29 +55,39 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
-      - name: Resolve + ensure tag
+          fetch-depth: 0  # full history + tags: the bump is computed from them
+
+      # Bump rules + the reasoning live in scripts/next-version.sh, which is
+      # regression-tested by scripts/test-next-version.sh in CI. It prints
+      # `key=value` lines on stdout and its log on stderr.
+      - name: Resolve tag
         id: t
-        run: |
-          set -euo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            TAG="${{ github.event.inputs.tag }}"
-            if ! git rev-parse "$TAG" >/dev/null 2>&1; then
-              git tag "$TAG"
-              git push origin "$TAG"
-            fi
-          else
-            TAG="${GITHUB_REF_NAME}"
-          fi
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-      - name: Create release (auto-generated notes)
+        env:
+          IS_TAG: ${{ startsWith(github.ref, 'refs/tags/') }}
+          REF_NAME: ${{ github.ref_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          INPUT_TAG: ${{ inputs.tag }}
+          INPUT_BUMP: ${{ inputs.bump }}
+        run: bash scripts/next-version.sh >> "$GITHUB_OUTPUT"
+
+      - name: Create tag + release (auto-generated notes)
+        if: steps.t.outputs.release == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.t.outputs.tag }}
         run: |
           set -euo pipefail
-          TAG="${{ steps.t.outputs.tag }}"
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Release $TAG already exists — nothing to do."
-          else
-            gh release create "$TAG" --title "$TAG" --generate-notes
+          if ! git rev-parse "${TAG}" >/dev/null 2>&1; then
+            git tag "${TAG}"
+            git push origin "${TAG}"
           fi
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "Release ${TAG} already exists — nothing to do."
+          else
+            gh release create "${TAG}" --title "${TAG}" --generate-notes
+          fi
+          echo "### Released \`${TAG}\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Summary (no release)
+        if: steps.t.outputs.release != 'true'
+        run: echo "No release cut for this event." >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/next-version.sh
+++ b/scripts/next-version.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Decide which release, if any, the current git state should produce.
+#
+# Writes GitHub-Actions-style `key=value` lines to STDOUT so a workflow can do
+#   ./scripts/next-version.sh >> "$GITHUB_OUTPUT"
+# All human-readable logging goes to STDERR (so it still shows in the run log
+# without polluting the outputs). Consumed by .github/workflows/release.yml.
+#
+# Inputs — all env, all optional; the defaults suit a local dry run:
+#   IS_TAG          "true" when the triggering ref is a tag
+#   REF_NAME        branch or tag name that triggered the run
+#   DEFAULT_BRANCH  the repo's default branch; only it may auto-release
+#   INPUT_TAG       explicit tag from a manual dispatch (wins if set)
+#   INPUT_BUMP      auto|patch|minor|major (default: auto)
+#
+# Outputs:
+#   release=true|false
+#   tag=vX.Y.Z      (only when release=true)
+#
+# Bump rules — conventional-commit subjects since the latest v*.*.* tag:
+#   `<type>!:` or a `BREAKING CHANGE` footer      → major
+#   `feat:`                                       → minor
+#   `fix:` / `perf:`                              → patch
+#   anything else (docs/chore/ci/test/refactor)   → no release
+#
+# Lives here rather than inline in the workflow so it can be regression-tested
+# (scripts/test-next-version.sh, run by CI). The inline version shipped with a
+# bug that the tests caught: `git describe --exact-match` ignores lightweight
+# tags without `--tags`, and the tags this repo cuts are lightweight.
+set -euo pipefail
+
+IS_TAG="${IS_TAG:-false}"
+REF_NAME="${REF_NAME:-}"
+DEFAULT_BRANCH="${DEFAULT_BRANCH:-}"
+INPUT_TAG="${INPUT_TAG:-}"
+INPUT_BUMP="${INPUT_BUMP:-}"
+
+log()  { echo "$*" >&2; }
+skip() { echo "release=false"; log "$1"; exit 0; }
+
+# ── 1. an explicit tag wins: a tag push, or a dispatch that named one
+if [ "${IS_TAG}" = "true" ]; then
+  log "Tag push: ${REF_NAME}"
+  echo "release=true"; echo "tag=${REF_NAME}"; exit 0
+fi
+if [ -n "${INPUT_TAG}" ]; then
+  log "Explicit tag requested: ${INPUT_TAG}"
+  echo "release=true"; echo "tag=${INPUT_TAG}"; exit 0
+fi
+
+# ── 2. auto-compute — only ever from the repo's own default branch
+if [ "${REF_NAME}" != "${DEFAULT_BRANCH}" ]; then
+  skip "Ref '${REF_NAME}' is not the default branch ('${DEFAULT_BRANCH}') — skipping."
+fi
+
+# HEAD already released → idempotent no-op, so re-runs are harmless.
+# `--tags` is load-bearing: without it describe only considers *annotated* tags,
+# and the tags this workflow creates are lightweight.
+if EXISTING="$(git describe --tags --exact-match --match 'v*.*.*' HEAD 2>/dev/null)"; then
+  skip "HEAD is already tagged ${EXISTING} — nothing to release."
+fi
+
+# `--sort=-v:refname` is a version sort, not lexical: v0.10.0 must beat v0.9.0.
+PREV="$(git tag -l 'v*.*.*' --sort=-v:refname | head -n1)"
+if [ -z "${PREV}" ]; then
+  PREV="v0.0.0"
+  RANGE="HEAD"            # no tag yet → the whole history is "since"
+else
+  RANGE="${PREV}..HEAD"
+fi
+LOG="$(git log --format='%s%n%b' "${RANGE}")"
+log "Commits since ${PREV}:"
+git log --format='  %h %s' "${RANGE}" >&2
+
+# ── 3. bump level
+#
+# A here-string, NOT `printf ... | grep -q`. `grep -q` exits the instant it
+# matches, so on a log bigger than the pipe buffer (~64K — i.e. any real
+# release range) the writer takes SIGPIPE, `pipefail` promotes that to a
+# non-zero pipeline status, and a log that *did* match reports "no match".
+# That bug shipped in the first draft of this script: 17 unit tests passed
+# because their synthetic repos were a few hundred bytes, while the real
+# 135K history silently resolved to "nothing to release".
+has() { grep -qE "$1" <<<"${LOG}"; }
+
+LEVEL="${INPUT_BUMP:-auto}"
+if [ "${LEVEL}" = "auto" ] || [ -z "${LEVEL}" ]; then
+  if has '^[a-z]+(\([^)]*\))?!:' || has '^BREAKING[ -]CHANGE'; then
+    LEVEL=major
+  elif has '^feat(\([^)]*\))?:'; then
+    LEVEL=minor
+  elif has '^(fix|perf)(\([^)]*\))?:'; then
+    LEVEL=patch
+  else
+    skip "No feat/fix/perf/breaking commits since ${PREV} — nothing to release."
+  fi
+fi
+
+IFS=. read -r MA MI PA <<<"${PREV#v}"
+case "${LEVEL}" in
+  major) MA=$((MA + 1)); MI=0; PA=0 ;;
+  minor) MI=$((MI + 1)); PA=0 ;;
+  patch) PA=$((PA + 1)) ;;
+  *) log "::error::unknown bump level '${LEVEL}'"; exit 1 ;;
+esac
+
+log "${PREV} → v${MA}.${MI}.${PA} (${LEVEL})"
+echo "release=true"
+echo "tag=v${MA}.${MI}.${PA}"

--- a/scripts/test-next-version.sh
+++ b/scripts/test-next-version.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Regression tests for scripts/next-version.sh — the semver bump the Release
+# workflow derives from conventional commits. Builds throwaway git repos in a
+# temp dir; touches nothing in this checkout. Run by CI.
+#
+# Usage: bash scripts/test-next-version.sh
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUT="${SUT:-${HERE}/next-version.sh}"  # overridable to diff-test a variant
+TMP="$(mktemp -d)"
+trap 'rm -rf "${TMP}"' EXIT
+PASS=0; FAIL=0
+
+# Isolated git identity so the tests don't depend on (or touch) user config.
+g() { git -c user.name=t -c user.email=t@example.com -c commit.gpgsign=false "$@"; }
+
+mkrepo() { rm -rf "${TMP}/$1"; mkdir -p "${TMP}/$1"; cd "${TMP}/$1"
+           g init -q -b dev; echo x > f; g add f; g commit -qm "chore: init"; }
+
+commit() { echo "$RANDOM$1" > "f$1"; g add "f$1"; g commit -qm "$1"; }
+
+# check <label> <expected-substring> [ENV=val ...]
+check() {
+  local label="$1" expect="$2"; shift 2
+  local out
+  # Defaults first so overrides win; release.yml always sets all five via `env:`.
+  out="$(env IS_TAG=false REF_NAME=dev DEFAULT_BRANCH=dev INPUT_TAG= INPUT_BUMP= \
+             "$@" bash "${SUT}" 2>&1)"
+  if grep -qF -- "$expect" <<<"$out"; then
+    echo "  ok   $label"; PASS=$((PASS + 1))
+  else
+    echo "  FAIL $label"
+    echo "       expected substring: $expect"
+    echo "       got: $(tr '\n' '|' <<<"$out")"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+mkrepo first-release
+commit "feat(api): add thing"
+check "no tag yet + feat → first release v0.1.0" "tag=v0.1.0"
+
+mkrepo minor; g tag v1.2.3; commit "feat(ui): new page"
+check "feat → minor" "tag=v1.3.0"
+
+mkrepo patch; g tag v1.2.3; commit "fix(api): boom"
+check "fix → patch" "tag=v1.2.4"
+
+mkrepo perf; g tag v1.2.3; commit "perf(api): faster"
+check "perf → patch" "tag=v1.2.4"
+
+mkrepo bang; g tag v1.2.3; commit "feat(api)!: drop v1 endpoints"
+check "type! → major" "tag=v2.0.0"
+
+mkrepo footer; g tag v1.2.3
+echo y > b; g add b; g commit -qm "refactor: rework config
+
+BREAKING CHANGE: config table renamed"
+check "BREAKING CHANGE footer → major" "tag=v2.0.0"
+
+mkrepo nothing; g tag v1.2.3; commit "docs: tidy readme"; commit "ci(deploy): bump runner"
+check "docs + ci only → no release" "release=false"
+
+mkrepo mixed; g tag v1.2.3; commit "fix: small"; commit "feat: big"
+check "highest level wins" "tag=v1.3.0"
+
+mkrepo already; commit "feat: x"; g tag v0.5.0
+check "HEAD already tagged → no-op" "already tagged v0.5.0"
+
+mkrepo branch; g tag v1.2.3; commit "feat: x"
+check "non-default branch → skip"        "release=false" REF_NAME=feat/x
+check "push to dev when default is main" "release=false" REF_NAME=dev DEFAULT_BRANCH=main
+check "tag push overrides analysis"      "tag=v9.9.9"    IS_TAG=true REF_NAME=v9.9.9
+check "explicit dispatch tag overrides"  "tag=v7.7.7"    REF_NAME=feat/x INPUT_TAG=v7.7.7
+
+mkrepo forced; g tag v1.2.3; commit "docs: nothing releasable"
+check "forced major on docs-only" "tag=v2.0.0" INPUT_BUMP=major
+check "forced minor on docs-only" "tag=v1.3.0" INPUT_BUMP=minor
+check "forced patch on docs-only" "tag=v1.2.4" INPUT_BUMP=patch
+
+mkrepo versionsort; g tag v0.9.0; g tag v0.10.0; commit "fix: x"
+check "v0.10.0 outranks v0.9.0 (version sort, not lexical)" "tag=v0.10.1"
+
+# Regression: the log must be matched with a here-string, not `… | grep -q`.
+# `grep -q` exits on first match; if the log exceeds the pipe buffer (~64K) the
+# writer takes SIGPIPE and `pipefail` reports the pipeline as failed, so a
+# matching log resolves to "nothing to release". Only a log larger than the pipe
+# buffer reproduces it — every other case here is a few hundred bytes.
+mkrepo bigrange; g tag v1.2.3
+BIG="$(printf 'filler body line %s\n' $(seq 1 6000))"   # ~130K, > pipe buffer
+echo big > c; g add c; g commit -qm "chore: bulky commit
+
+${BIG}"
+commit "fix(api): the newest commit matches on line 1"
+check "log larger than the pipe buffer still matches" "tag=v1.2.4"
+
+echo
+echo "next-version: passed=${PASS} failed=${FAIL}"
+[ "${FAIL}" -eq 0 ]


### PR DESCRIPTION
## What was wrong

A merge built and passed CI — and then left the version exactly where it was. `release.yml` only triggered on:

- `push: tags: ["v*.*.*"]` — a hand-pushed tag
- `workflow_dispatch` — a manual run

Nothing fired on a merge, and nothing computed a version. So every release so far (`v0.1.0`, `v0.2.0`, `v0.3.0`) happened only because someone remembered to tag, and `main` has been sitting ahead of `v0.3.0` since the last merge.

## The fix

`release.yml` now also fires on a push to the default branch and derives the next version from the conventional-commit subjects since the last tag:

| Commits since last tag | Bump |
|---|---|
| `<type>!:` or a `BREAKING CHANGE` footer | major |
| `feat:` | minor |
| `fix:` / `perf:` | patch |
| anything else (docs/chore/ci/test/refactor) | **no release** — a docs-only merge stays silent |

Explicit tag pushes and manual dispatch still win, `bump` can force a level, and a tagged HEAD is an idempotent no-op so re-runs are safe.

### Two deliberate design points

- **The tag is created and the release cut in the same run.** A tag pushed with `GITHUB_TOKEN` does *not* trigger other workflows, so the obvious "push a tag, let the tag trigger the release" split would silently never fire — which is the exact class of bug being fixed here.
- **`branches: [main, dev]` with a guard on `github.event.repository.default_branch`** rather than naming one branch, so the file works unchanged regardless of which branch a given checkout treats as default. A push to a non-default branch is a logged no-op.

## Why the logic is a script, not inline YAML

`scripts/next-version.sh` + `scripts/test-next-version.sh` (18 cases, new `release-version` CI job — throwaway git repos in a temp dir, no dependencies, a couple of seconds).

The tests earned their keep twice while this was being written:

1. `git describe --exact-match` only considers **annotated** tags unless you pass `--tags` — and the tags this workflow cuts are lightweight, so the "already released" guard would never have fired.
2. `printf … | grep -q` under `pipefail` reports a **matched** log as no-match once the log exceeds the pipe buffer (~64K): `grep -q` exits on the first match, the writer takes SIGPIPE, and `pipefail` promotes that to a failed pipeline. A real 135K history resolved to "nothing to release" while 17 small-repo tests passed, because every synthetic repo was a few hundred bytes. Now matched with a here-string, guarded by a deliberately >64K regression case.

Dry-run against this branch: `v0.3.0` → **`v0.3.1`** (patch, from the `fix(inventory)` merge).

## Note

`services/api/pyproject.toml` and `services/ui/package.json` each carry an independent `version = "0.1.0"` that this flow does **not** bump. Nothing is published to PyPI/npm, so they're inert — the git tag is the version of record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
