### PR TITLE
fix(api): keep blocking git + state-store I/O off the event loop

### DIFF
--- a/services/api/app/routers/state.py
+++ b/services/api/app/routers/state.py
@@ -3,6 +3,7 @@
 Provides GET/POST for state, POST/DELETE for lock.
 These endpoints are internal (used by Terraform directly).
 """
+import asyncio
 import json
 import logging
 import os
@@ -164,7 +165,12 @@ async def get_state(
 
     try:
         svc, key = await _service_for(ws, db)
-        data = svc.get_state_at(key)
+        # StateStore is a *sync* contract (see services/state_store.py) backed by
+        # boto3 / azure-blob / gcs clients. Called inline it parks the event loop
+        # for the whole round trip — a cross-account GetObject plus a full-body
+        # read of a multi-MB tfstate — and this is the hottest state route
+        # (every terraform refresh/plan hits it). Offload to a worker thread.
+        data = await asyncio.to_thread(svc.get_state_at, key)
     except Exception:
         logger.exception("State fetch failed for workspace %s", workspace_id)
         raise HTTPException(
@@ -228,7 +234,9 @@ async def put_state(
 
     try:
         svc, key = await _service_for(ws, db)
-        svc.put_state_at(key, body)
+        # Same reasoning as the GET path — an upload of the full state body must
+        # not block every other request while it is in flight.
+        await asyncio.to_thread(svc.put_state_at, key, body)
     except Exception:
         logger.exception("Failed to persist state for workspace %s", workspace_id)
         raise HTTPException(status_code=500, detail="Failed to persist state")

--- a/services/api/app/services/repo_sync.py
+++ b/services/api/app/services/repo_sync.py
@@ -25,6 +25,7 @@ Design:
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import subprocess
@@ -158,7 +159,12 @@ async def check_workspace_paths(
     for (repo_url, ref, bu_id), wss in groups.items():
         bu_slug = await _bu_slug_by_id(session, bu_id)
         username, token = await _resolve_token(session, repo_url, bu_slug)
-        tmpdir, err = _shallow_clone(repo_url, ref, username, token)
+        # `_shallow_clone` shells out to git and blocks for as long as the clone
+        # takes (up to its own 60s timeout). Run it on a worker thread — calling
+        # it inline would park the whole event loop, and this loop iterates once
+        # per (repo, ref, bu) group, so the API would stop serving *every*
+        # request for the duration of the sync pass.
+        tmpdir, err = await asyncio.to_thread(_shallow_clone, repo_url, ref, username, token)
         if err:
             res.errors.append(f"{_redact_url(repo_url)} @ {ref}: {err}")
             # Leave each workspace's path_status untouched on clone error.
@@ -179,7 +185,9 @@ async def check_workspace_paths(
                 ws.path_status_checked_at = datetime.now(timezone.utc)
                 res.checked += 1
         finally:
-            _cleanup(tmpdir)
+            # rmtree over a freshly cloned worktree can be thousands of unlinks;
+            # keep it off the event loop for the same reason as the clone.
+            await asyncio.to_thread(_cleanup, tmpdir)
 
     return res
 
@@ -235,8 +243,6 @@ async def repo_sync_loop(session_factory):
     logged and swallowed — a transient git outage must not kill the
     loop.
     """
-    import asyncio
-
     await asyncio.sleep(60)
     while True:
         try:

--- a/services/api/tests/test_event_loop_not_blocked.py
+++ b/services/api/tests/test_event_loop_not_blocked.py
@@ -1,0 +1,182 @@
+"""Regression guards: blocking I/O must not run on the event loop.
+
+The API serves from a single uvicorn worker (`docker-entrypoint.sh` execs
+uvicorn with no `--workers`), so a synchronous call made directly from an
+`async def` parks *every* in-flight request for its full duration. Two paths
+did exactly that:
+
+- `repo_sync._shallow_clone` shells out to `git clone` — `subprocess.run(...,
+  timeout=60)` — once per (repo, ref, bu) group. Across a fleet of workspaces a
+  sync pass froze the API repeatedly, with worst-case response times pinned to
+  that 60s clone timeout.
+- `routers/state.get_state` / `put_state` call the deliberately *sync*
+  `StateStore` contract (boto3 / azure-blob / gcs) inline, so a cross-account
+  GetObject plus a full-body read of a multi-MB tfstate blocked everything.
+
+Each test drives the real code path with only the blocking leaf replaced by a
+`time.sleep`, while a ticker coroutine counts how often the loop regained
+control. Inline blocking yields ~0 ticks; offloaded work yields many. These
+tests fail if either call site is ever moved back onto the loop.
+"""
+import asyncio
+import time
+
+import pytest
+
+from app.auth.internal_token import StateAuth
+from app.models.business_unit import DEFAULT_BU_ID
+from app.models.workspace import Workspace
+from app.routers import state as state_router
+from app.services import repo_sync as rsync
+
+
+pytestmark = pytest.mark.usefixtures("default_bu")
+
+# How long the stand-in blocking call takes.
+BLOCK_SECONDS = 0.30
+# How often the ticker tries to run.
+TICK_SECONDS = 0.01
+# Perfectly interleaved we would see ~30 ticks. Assert a low floor so a loaded
+# CI box cannot flake this, while inline blocking (0-1 ticks) still fails hard.
+MIN_TICKS = 5
+
+
+class _Ticker:
+    """Counts event-loop iterations while running as a background task."""
+
+    def __init__(self) -> None:
+        self.ticks = 0
+        self._task: asyncio.Task | None = None
+
+    async def __aenter__(self) -> "_Ticker":
+        async def _run() -> None:
+            while True:
+                await asyncio.sleep(TICK_SECONDS)
+                self.ticks += 1
+
+        self._task = asyncio.create_task(_run())
+        await asyncio.sleep(0)  # let the task reach its first await
+        return self
+
+    async def __aexit__(self, *exc) -> bool:
+        self._task.cancel()
+        try:
+            await self._task
+        except asyncio.CancelledError:
+            pass
+        return False
+
+
+def _ws(name: str, tf_dir: str = ".", repo: str = "https://github.com/o/r", ref: str = "main") -> Workspace:
+    return Workspace(
+        business_unit_id=DEFAULT_BU_ID,
+        name=name,
+        aws_account_id="123456789012",
+        region="us-east-1",
+        environment="dev",
+        repo_url=repo,
+        repo_ref=ref,
+        tf_working_dir=tf_dir,
+    )
+
+
+async def test_repo_sync_clone_does_not_block_event_loop(db_session, monkeypatch):
+    """`check_workspace_paths` must clone off the loop."""
+
+    def blocking_clone(*a, **k):
+        time.sleep(BLOCK_SECONDS)  # stands in for subprocess.run(["git", "clone", ...])
+        return ("/tmp/clone", None)
+
+    monkeypatch.setattr(rsync, "_shallow_clone", blocking_clone)
+    monkeypatch.setattr(rsync, "_cleanup", lambda d: None)
+
+    async with _Ticker() as ticker:
+        res = await rsync.check_workspace_paths(db_session, [_ws("a")])
+
+    assert res.checked == 1 and res.ok == 1
+    assert ticker.ticks >= MIN_TICKS, (
+        f"event loop was blocked during git clone (ticks={ticker.ticks}) — "
+        "_shallow_clone must be awaited via asyncio.to_thread"
+    )
+
+
+async def test_repo_sync_cleanup_does_not_block_event_loop(db_session, monkeypatch):
+    """rmtree of a cloned worktree must also stay off the loop."""
+    monkeypatch.setattr(rsync, "_shallow_clone", lambda *a, **k: ("/tmp/clone", None))
+
+    def blocking_cleanup(tmpdir):
+        time.sleep(BLOCK_SECONDS)  # stands in for shutil.rmtree over a worktree
+
+    monkeypatch.setattr(rsync, "_cleanup", blocking_cleanup)
+
+    async with _Ticker() as ticker:
+        await rsync.check_workspace_paths(db_session, [_ws("a")])
+
+    assert ticker.ticks >= MIN_TICKS, (
+        f"event loop was blocked during cleanup (ticks={ticker.ticks}) — "
+        "_cleanup must be awaited via asyncio.to_thread"
+    )
+
+
+async def test_state_get_does_not_block_event_loop(db_session, monkeypatch):
+    """GET /api/v1/state/{ws} must read from the store off the loop."""
+    ws = _ws("slow-store")
+    db_session.add(ws)
+    await db_session.commit()
+
+    class _SlowStore:
+        def get_state_at(self, key: str) -> bytes:
+            time.sleep(BLOCK_SECONDS)  # stands in for GetObject + Body.read()
+            return b'{"version": 4}'
+
+    async def fake_service_for(workspace, db):
+        return _SlowStore(), "leaf/terraform.tfstate"
+
+    monkeypatch.setattr(state_router, "_service_for", fake_service_for)
+
+    async with _Ticker() as ticker:
+        resp = await state_router.get_state(ws.id, StateAuth(workspace_id=None), db_session)
+
+    assert resp.status_code == 200
+    assert ticker.ticks >= MIN_TICKS, (
+        f"event loop was blocked during state read (ticks={ticker.ticks}) — "
+        "get_state_at must be awaited via asyncio.to_thread"
+    )
+
+
+async def test_state_put_does_not_block_event_loop(db_session, monkeypatch):
+    """POST /api/v1/state/{ws} must write to the store off the loop."""
+    ws = _ws("slow-store-put")
+    db_session.add(ws)
+    await db_session.commit()
+
+    written: dict = {}
+
+    class _SlowStore:
+        def put_state_at(self, key: str, state_bytes: bytes) -> None:
+            time.sleep(BLOCK_SECONDS)  # stands in for PutObject
+            written["key"] = key
+
+    async def fake_service_for(workspace, db):
+        return _SlowStore(), "leaf/terraform.tfstate"
+
+    monkeypatch.setattr(state_router, "_service_for", fake_service_for)
+
+    body = b'{"version": 4, "resources": []}'
+
+    class _Req:
+        headers: dict = {}  # no content-length → skips the declared-size check
+
+        async def body(self) -> bytes:
+            return body
+
+    async with _Ticker() as ticker:
+        resp = await state_router.put_state(
+            ws.id, _Req(), StateAuth(workspace_id=None), db_session
+        )
+
+    assert resp.status_code == 200 and written["key"] == "leaf/terraform.tfstate"
+    assert ticker.ticks >= MIN_TICKS, (
+        f"event loop was blocked during state write (ticks={ticker.ticks}) — "
+        "put_state_at must be awaited via asyncio.to_thread"
+    )


### PR DESCRIPTION
## The bug

The API serves from a **single uvicorn worker** (`docker-entrypoint.sh` execs uvicorn with no `--workers`), so a synchronous call made directly from an `async def` parks *every* in-flight request for its full duration. Nothing under `services/api/app` was offloaded — `grep -c 'to_thread\|run_in_executor'` returned **0** — and two hot paths did exactly that:

| Path | Blocking call |
|---|---|
| `repo_sync._shallow_clone` (via `check_workspace_paths`) | `subprocess.run(["git","clone",…], timeout=60)` inline, once per `(repo, ref, bu)` group on every sync pass |
| `routers/state.get_state` / `put_state` | the deliberately **sync** `StateStore` contract inline — a cross-account GetObject plus a full-body read of a multi-MB tfstate |

The symptom is distinctive and easy to misread: **near-idle CPU alongside multi-second tail latency**, with the worst-case response time pinned to the clone's own 60s timeout. That's an event loop parked in `subprocess.run`, not a CPU-saturated service — so scaling up instance size doesn't help.

`get_state` is the hottest state route; every `terraform refresh`/`plan` hits it.

## The fix

Offload the four blocking leaves via `asyncio.to_thread`:

- `_shallow_clone` (the `git clone`)
- `_cleanup` (the worktree `rmtree` — potentially thousands of unlinks)
- `svc.get_state_at`
- `svc.put_state_at`

Plus promote `repo_sync`'s function-local `import asyncio` to module scope so the new call sites resolve. The `StateStore` contract stays sync by design — only the call sites change.

## Tests

`tests/test_event_loop_not_blocked.py` drives each **real** code path with only the blocking leaf swapped for a `time.sleep`, while a ticker coroutine counts how often the loop regained control. Inline blocking scores ~0 ticks; offloaded work scores many.

Verified red before green in this branch: reverting just the two source files to their pre-fix versions fails all four tests, and restoring passes all four. So these genuinely guard the call sites rather than merely passing.

```
4 failed   ← pre-fix sources
4 passed   ← with the fix
```

## Deliberately out of scope

- `--workers > 1` — `repo_sync_loop` is per-process, so scaling out would multiply the sync pass N-fold; it needs leader election first.
- Replacing the clone with `git ls-remote`.
- Backoff for permanently failing refs.
- `scan_terraform_state_json` — CPU-bound, so a thread wouldn't help; it needs a process pool or a different approach.
- Per-request `boto3.client()` construction — measured (cold ~106ms, warm median ~4ms, a negligible share of the CPU budget at the observed call rate) and left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
