### PR TITLE
feat: colour-code runs by cloud account (UI rail + Slack stripe)

### DIFF
--- a/services/api/alembic/versions/041_account_color.py
+++ b/services/api/alembic/versions/041_account_color.py
@@ -1,0 +1,74 @@
+"""Cloud accounts: optional `color` label for at-a-glance run attribution.
+
+One nullable VARCHAR(16) on each of the four cloud-account tables. The value is
+a token from `app.services.account_colors.ACCOUNT_COLORS` (red/orange/yellow/
+green/blue/purple/brown/gray), NOT a hex — see that module for why.
+
+The API claims a colour at creation time (first one unused in the BU), so
+colours are guaranteed distinct up to 8 accounts per BU and never shift
+afterwards. This revision backfills every pre-existing row the same way, so
+nobody has to visit Settings to get a usable palette. NULL survives only for
+rows inserted outside the API (seed scripts, direct SQL), which the API paints
+via a hash fallback.
+
+Deliberately no CHECK constraint / enum type: the allowed set is validated in
+the Pydantic layer, and a DB-level enum would need its own migration every time
+a colour is appended.
+
+Revision ID: 041_account_color
+Revises: 040_azure_state_storage
+Create Date: 2026-08-19
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "041_account_color"
+down_revision = "040_azure_state_storage"
+branch_labels = None
+depends_on = None
+
+_TABLES = ("aws_accounts", "azure_subscriptions", "gcp_projects", "k8s_clusters")
+
+
+# Snapshot of app.services.account_colors.ACCOUNT_COLORS at this revision.
+# Inlined rather than imported: a migration must keep producing the same result
+# forever, even after the palette in the application code grows.
+_PALETTE = ("red", "orange", "yellow", "green", "blue", "purple", "brown", "gray")
+
+
+def upgrade() -> None:
+    for table in _TABLES:
+        op.add_column(table, sa.Column("color", sa.String(length=16), nullable=True))
+    _backfill()
+
+
+def _backfill() -> None:
+    """Give every existing account a colour, distinct within its Business Unit.
+
+    Walks all four provider tables together (a colour reused across providers
+    is as confusing as one reused within a provider) in a deterministic order —
+    BU, then table, then name — and round-robins the palette. Ordering by name
+    rather than created_at keeps the result reproducible across environments
+    whose rows were created in a different sequence.
+    """
+    bind = op.get_bind()
+    rows = []
+    for table_rank, table in enumerate(_TABLES):
+        result = bind.execute(sa.text(f"SELECT id, business_unit_id, name FROM {table}"))  # noqa: S608
+        for r in result.mappings():
+            rows.append((r["business_unit_id"] or "", table_rank, r["name"] or "", r["id"], table))
+
+    rows.sort(key=lambda r: r[:4])
+    seen_per_bu: dict[str, int] = {}
+    for bu_id, _rank, _name, row_id, table in rows:
+        n = seen_per_bu.get(bu_id, 0)
+        seen_per_bu[bu_id] = n + 1
+        bind.execute(
+            sa.text(f"UPDATE {table} SET color = :c WHERE id = :i"),  # noqa: S608
+            {"c": _PALETTE[n % len(_PALETTE)], "i": row_id},
+        )
+
+
+def downgrade() -> None:
+    for table in reversed(_TABLES):
+        op.drop_column(table, "color")

--- a/services/api/app/models/aws_account.py
+++ b/services/api/app/models/aws_account.py
@@ -31,6 +31,11 @@ class AwsAccount(Base):
     # Human-readable display name (e.g. "example-prod").
     name: Mapped[str] = mapped_column(String(120), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Optional UI colour token (see app.services.account_colors). Purely
+    # cosmetic: paints a rail on Runs rows and the Slack attachment stripe so
+    # humans can attribute a run to an account at a glance. NULL = auto —
+    # the API derives a stable colour from the account's natural id.
+    color: Mapped[str | None] = mapped_column(String(16), nullable=True)
     # Dedicated state bucket for this account.
     state_bucket: Mapped[str] = mapped_column(String(255), nullable=False)
     state_bucket_region: Mapped[str] = mapped_column(String(50), nullable=False, default="us-east-1")

--- a/services/api/app/models/azure_subscription.py
+++ b/services/api/app/models/azure_subscription.py
@@ -39,6 +39,11 @@ class AzureSubscription(Base):
     # Human-readable display name (e.g. "acme-prod").
     name: Mapped[str] = mapped_column(String(120), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Optional UI colour token (see app.services.account_colors). Purely
+    # cosmetic: paints a rail on Runs rows and the Slack attachment stripe so
+    # humans can attribute a run to an account at a glance. NULL = auto —
+    # the API derives a stable colour from the account's natural id.
+    color: Mapped[str | None] = mapped_column(String(16), nullable=True)
     default_location: Mapped[str] = mapped_column(String(50), nullable=False, default="eastus")
     # Optional Azure Blob state backend. When a workspace sets
     # state_backend=azureblob, its Terraform state is stored in this container,

--- a/services/api/app/models/gcp_project.py
+++ b/services/api/app/models/gcp_project.py
@@ -34,6 +34,11 @@ class GcpProject(Base):
     # Human-readable display name (e.g. "acme-prod").
     name: Mapped[str] = mapped_column(String(120), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Optional UI colour token (see app.services.account_colors). Purely
+    # cosmetic: paints a rail on Runs rows and the Slack attachment stripe so
+    # humans can attribute a run to an account at a glance. NULL = auto —
+    # the API derives a stable colour from the account's natural id.
+    color: Mapped[str | None] = mapped_column(String(16), nullable=True)
     default_region: Mapped[str] = mapped_column(String(50), nullable=False, default="us-central1")
     # Optional GCS bucket for `state_backend=gcs` workspaces. Nullable so a
     # provider-only GCP project (state still in S3) validates fine.

--- a/services/api/app/models/k8s_cluster.py
+++ b/services/api/app/models/k8s_cluster.py
@@ -29,6 +29,11 @@ class K8sCluster(Base):
     # Human-readable display name (e.g. "prod-eks"). Unique per BU.
     name: Mapped[str] = mapped_column(String(120), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Optional UI colour token (see app.services.account_colors). Purely
+    # cosmetic: paints a rail on Runs rows and the Slack attachment stripe so
+    # humans can attribute a run to an account at a glance. NULL = auto —
+    # the API derives a stable colour from the account's natural id.
+    color: Mapped[str | None] = mapped_column(String(16), nullable=True)
     # Optional API server URL, surfaced for display / connectivity testing.
     server_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     # Default namespace used by helm runs when a workspace doesn't override it.

--- a/services/api/app/routers/aws_accounts.py
+++ b/services/api/app/routers/aws_accounts.py
@@ -21,7 +21,7 @@ from app.schemas.aws_account import (
     AwsAccountUpdate,
     CreateBucketResult,
 )
-from app.services import aws_account_service as accs
+from app.services import account_colors, aws_account_service as accs
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +46,8 @@ def _to_response(acc: AwsAccount) -> AwsAccountResponse:
         state_bucket_region=acc.state_bucket_region,
         default_region=acc.default_region,
         aws_profile_name=acc.aws_profile_name,
+        color=acc.color,
+        color_effective=account_colors.effective(acc.color, acc.account_id),
         access_key_id_masked=accs.mask_access_key_tail(plain_key) if plain_key else "(unreadable)",
     )
 
@@ -102,6 +104,9 @@ async def create_aws_account(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"AWS account {body.account_id} is already configured in this business unit",
         )
+    # Claim a colour up-front so it's stored once and never shifts. Explicit
+    # choice wins; otherwise the first colour unused in this BU.
+    color = await account_colors.assign_for_bu(db, bu.bu_id, body.color)
     acc = AwsAccount(
         id=str(uuid.uuid4()),
         business_unit_id=bu.bu_id,
@@ -112,6 +117,7 @@ async def create_aws_account(
         state_bucket_region=body.state_bucket_region,
         default_region=body.default_region,
         aws_profile_name=body.aws_profile_name,
+        color=color,
         access_key_id_encrypted=accs.encrypt_secret(body.access_key_id),
         secret_access_key_encrypted=accs.encrypt_secret(body.secret_access_key),
     )

--- a/services/api/app/routers/azure_subscriptions.py
+++ b/services/api/app/routers/azure_subscriptions.py
@@ -20,6 +20,7 @@ from app.schemas.azure_subscription import (
     AzureSubscriptionTestResult,
     AzureSubscriptionUpdate,
 )
+from app.services import account_colors
 from app.services import azure_subscription_service as svc
 from app.services.azure_blob_state_service import AzureBlobStateService
 
@@ -44,6 +45,8 @@ def _to_response(sub: AzureSubscription) -> AzureSubscriptionResponse:
         default_location=sub.default_location,
         state_storage_account=sub.state_storage_account,
         state_container=sub.state_container,
+        color=sub.color,
+        color_effective=account_colors.effective(sub.color, sub.subscription_id),
         client_secret_masked=svc.mask_secret_tail(plain) if plain else "(unreadable)",
     )
 
@@ -92,6 +95,8 @@ async def create_azure_subscription(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"Azure subscription {body.subscription_id} is already configured in this business unit",
         )
+    # See aws_accounts.create_aws_account — colour claimed at creation.
+    color = await account_colors.assign_for_bu(db, bu.bu_id, body.color)
     sub = AzureSubscription(
         id=str(uuid.uuid4()),
         business_unit_id=bu.bu_id,
@@ -103,6 +108,7 @@ async def create_azure_subscription(
         default_location=body.default_location,
         state_storage_account=body.state_storage_account,
         state_container=body.state_container,
+        color=color,
         client_secret_encrypted=svc.encrypt_secret(body.client_secret),
     )
     db.add(sub)

--- a/services/api/app/routers/clusters.py
+++ b/services/api/app/routers/clusters.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.bu_context import BUScope, current_bu
@@ -23,6 +23,7 @@ from app.auth.rbac import Role, require_role
 from app.db import get_db
 from app.models.k8s_cluster import K8sCluster
 from app.models.user import User
+from app.services import account_colors
 from app.services import cluster_service as clusters
 
 logger = logging.getLogger(__name__)
@@ -40,8 +41,16 @@ class ClusterCreate(BaseModel):
     # Optional AWS account (12-digit id) whose creds authenticate to EKS via
     # the kubeconfig's `aws eks get-token` exec plugin. Null for non-EKS.
     aws_account_id: Optional[str] = None
+    # Cosmetic UI/Slack colour token; None/"" = auto-derive. See
+    # app.services.account_colors.
+    color: Optional[str] = None
     # Full kubeconfig YAML. Encrypted at rest; never echoed back.
     kubeconfig: str = Field(..., min_length=1)
+
+    @field_validator("color")
+    @classmethod
+    def _color(cls, v: Optional[str]) -> Optional[str]:
+        return account_colors.normalize(v)
 
 
 class ClusterUpdate(BaseModel):
@@ -50,8 +59,15 @@ class ClusterUpdate(BaseModel):
     server_url: Optional[str] = None
     default_namespace: Optional[str] = None
     aws_account_id: Optional[str] = None
+    # Send "" (or null) to clear back to the auto-derived colour.
+    color: Optional[str] = None
     # If supplied we re-encrypt on the server.
     kubeconfig: Optional[str] = None
+
+    @field_validator("color")
+    @classmethod
+    def _color(cls, v: Optional[str]) -> Optional[str]:
+        return account_colors.normalize(v)
 
 
 class ClusterResponse(BaseModel):
@@ -63,6 +79,10 @@ class ClusterResponse(BaseModel):
     server_url: Optional[str] = None
     default_namespace: Optional[str] = None
     aws_account_id: Optional[str] = None
+    # `color` is what's stored (None = auto); `color_effective` is what the
+    # UI paints and is always populated. See app.services.account_colors.
+    color: Optional[str] = None
+    color_effective: str = "gray"
     kubeconfig_tail: str
     created_at: Optional[datetime] = None
 
@@ -92,6 +112,8 @@ def _to_response(c: K8sCluster) -> ClusterResponse:
         server_url=c.server_url,
         default_namespace=c.default_namespace,
         aws_account_id=getattr(c, "aws_account_id", None),
+        color=c.color,
+        color_effective=account_colors.effective(c.color, c.id),
         kubeconfig_tail=tail,
         created_at=getattr(c, "created_at", None),
     )
@@ -121,6 +143,8 @@ async def create_cluster(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Set X-Business-Unit header to a specific BU when creating a cluster",
         )
+    # See aws_accounts.create_aws_account — colour claimed at creation.
+    color = await account_colors.assign_for_bu(db, bu.bu_id, body.color)
     try:
         cluster = await clusters.create_cluster(
             db,
@@ -130,6 +154,7 @@ async def create_cluster(
             server_url=body.server_url,
             default_namespace=body.default_namespace,
             aws_account_id=body.aws_account_id,
+            color=color,
             kubeconfig=body.kubeconfig,
         )
     except clusters.UnsafeKubeconfigError as e:
@@ -160,6 +185,8 @@ async def update_cluster(
             kubeconfig=data.get("kubeconfig"),
             aws_account_id=data.get("aws_account_id"),
             aws_account_id_set=("aws_account_id" in data),
+            color=data.get("color"),
+            color_set=("color" in data),
         )
     except clusters.UnsafeKubeconfigError as e:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e))

--- a/services/api/app/routers/drift.py
+++ b/services/api/app/routers/drift.py
@@ -183,7 +183,7 @@ async def submit_drift_report(
         await db.commit()
 
     if body.has_drift:
-        await send_drift_alert(db, ws.name, body.summary)
+        await send_drift_alert(db, ws.name, body.summary, workspace_id=ws.id)
 
     return DriftReportOut(
         report_id=report.id,

--- a/services/api/app/routers/gcp_projects.py
+++ b/services/api/app/routers/gcp_projects.py
@@ -21,6 +21,7 @@ from app.schemas.gcp_project import (
     GcpProjectTestResult,
     GcpProjectUpdate,
 )
+from app.services import account_colors
 from app.services import gcp_project_service as svc
 from app.services.gcs_state_service import GcsStateService
 
@@ -40,6 +41,8 @@ def _to_response(proj: GcpProject) -> GcpProjectResponse:
         default_region=proj.default_region,
         state_bucket=proj.state_bucket,
         state_prefix=proj.state_prefix,
+        color=proj.color,
+        color_effective=account_colors.effective(proj.color, proj.project_id),
         service_account_masked=svc.mask_sa(proj.client_email),
     )
 
@@ -98,6 +101,8 @@ async def create_gcp_project(
             status_code=status.HTTP_409_CONFLICT,
             detail=f"GCP project {body.project_id} is already configured in this business unit",
         )
+    # See aws_accounts.create_aws_account — colour claimed at creation.
+    color = await account_colors.assign_for_bu(db, bu.bu_id, body.color)
     proj = GcpProject(
         id=str(uuid.uuid4()),
         business_unit_id=bu.bu_id,
@@ -108,6 +113,7 @@ async def create_gcp_project(
         default_region=body.default_region,
         state_bucket=body.state_bucket,
         state_prefix=body.state_prefix,
+        color=color,
         service_account_json_encrypted=svc.encrypt_secret(body.service_account_json),
     )
     db.add(proj)

--- a/services/api/app/routers/runs.py
+++ b/services/api/app/routers/runs.py
@@ -417,6 +417,9 @@ async def patch_run(
                         run.id,
                         notification_payload["workspace_name"],
                         notification_payload["plan_output"],
+                        # Lets the message carry the account's stripe + emoji,
+                        # matching the bot-token path.
+                        workspace_id=run.workspace_id,
                     )
                 except (httpx.RequestError, smtplib.SMTPException, OSError):
                     logger.warning(

--- a/services/api/app/schemas/aws_account.py
+++ b/services/api/app/schemas/aws_account.py
@@ -3,6 +3,8 @@ from typing import Optional
 
 from pydantic import BaseModel, Field, field_validator
 
+from app.services import account_colors
+
 
 class AwsAccountCreate(BaseModel):
     account_id: str = Field(..., pattern=r"^\d{12}$")
@@ -12,8 +14,15 @@ class AwsAccountCreate(BaseModel):
     state_bucket_region: str = "us-east-1"
     default_region: str = "us-east-1"
     aws_profile_name: Optional[str] = None
+    # Cosmetic UI/Slack colour token; None/"" = auto-derive. See account_colors.
+    color: Optional[str] = None
     access_key_id: str = Field(..., min_length=4)
     secret_access_key: str = Field(..., min_length=4)
+
+    @field_validator("color")
+    @classmethod
+    def _color(cls, v: Optional[str]) -> Optional[str]:
+        return account_colors.normalize(v)
 
     @field_validator("state_bucket")
     @classmethod
@@ -32,9 +41,16 @@ class AwsAccountUpdate(BaseModel):
     state_bucket_region: Optional[str] = None
     default_region: Optional[str] = None
     aws_profile_name: Optional[str] = None
+    # Send "" (or null) to clear back to the auto-derived colour.
+    color: Optional[str] = None
     # If either credential is provided we re-encrypt on the server.
     access_key_id: Optional[str] = None
     secret_access_key: Optional[str] = None
+
+    @field_validator("color")
+    @classmethod
+    def _color(cls, v: Optional[str]) -> Optional[str]:
+        return account_colors.normalize(v)
 
 
 class AwsAccountResponse(BaseModel):
@@ -52,6 +68,12 @@ class AwsAccountResponse(BaseModel):
     state_bucket_region: str
     default_region: str
     aws_profile_name: Optional[str] = None
+    # `color` is what's stored (None = auto, so Settings can show "Auto"
+    # selected); `color_effective` is what the UI actually paints and is
+    # always populated. Two fields so the derived-default hash lives in
+    # exactly one place — the server.
+    color: Optional[str] = None
+    color_effective: str = "gray"
     access_key_id_masked: str
 
     model_config = {"from_attributes": False}

--- a/services/api/app/schemas/azure_subscription.py
+++ b/services/api/app/schemas/azure_subscription.py
@@ -3,6 +3,8 @@ from typing import Optional
 
 from pydantic import BaseModel, Field, field_validator
 
+from app.services import account_colors
+
 # Azure tenant/subscription/client/object ids are UUIDs. Accept the canonical
 # 8-4-4-4-12 hex form, case-insensitive.
 _UUID_PATTERN = r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
@@ -23,6 +25,13 @@ class AzureSubscriptionCreate(BaseModel):
     state_container: Optional[str] = Field(
         default=None, pattern=r"^[a-z0-9]([a-z0-9-]{1,61}[a-z0-9])$"
     )
+    # Cosmetic UI/Slack colour token; None/"" = auto-derive. See account_colors.
+    color: Optional[str] = None
+
+    @field_validator("color")
+    @classmethod
+    def _color(cls, v: Optional[str]) -> Optional[str]:
+        return account_colors.normalize(v)
 
     @field_validator("subscription_id", "tenant_id", "client_id")
     @classmethod
@@ -36,8 +45,15 @@ class AzureSubscriptionUpdate(BaseModel):
     default_location: Optional[str] = None
     state_storage_account: Optional[str] = None
     state_container: Optional[str] = None
+    # Send "" (or null) to clear back to the auto-derived colour.
+    color: Optional[str] = None
     # If client_secret is provided we re-encrypt it on the server.
     client_secret: Optional[str] = None
+
+    @field_validator("color")
+    @classmethod
+    def _color(cls, v: Optional[str]) -> Optional[str]:
+        return account_colors.normalize(v)
 
 
 class AzureSubscriptionResponse(BaseModel):
@@ -56,6 +72,12 @@ class AzureSubscriptionResponse(BaseModel):
     default_location: str
     state_storage_account: Optional[str] = None
     state_container: Optional[str] = None
+    # `color` is what's stored (None = auto, so Settings can show "Auto"
+    # selected); `color_effective` is what the UI actually paints and is
+    # always populated. Two fields so the derived-default hash lives in
+    # exactly one place — the server.
+    color: Optional[str] = None
+    color_effective: str = "gray"
     client_secret_masked: str
 
     model_config = {"from_attributes": False}

--- a/services/api/app/schemas/gcp_project.py
+++ b/services/api/app/schemas/gcp_project.py
@@ -4,6 +4,8 @@ from typing import Optional
 
 from pydantic import BaseModel, Field, field_validator
 
+from app.services import account_colors
+
 # GCP project ids: 6-30 chars, start with a lowercase letter, then lowercase
 # letters / digits / hyphens, no trailing hyphen.
 _PROJECT_ID_PATTERN = r"^[a-z][a-z0-9-]{4,28}[a-z0-9]$"
@@ -36,6 +38,13 @@ class GcpProjectCreate(BaseModel):
     # The full service-account key JSON (pasted from the downloaded key file).
     # Validated structurally here; encrypted at rest by the service layer.
     service_account_json: str = Field(..., min_length=50)
+    # Cosmetic UI/Slack colour token; None/"" = auto-derive. See account_colors.
+    color: Optional[str] = None
+
+    @field_validator("color")
+    @classmethod
+    def _color(cls, v: Optional[str]) -> Optional[str]:
+        return account_colors.normalize(v)
 
     @field_validator("service_account_json")
     @classmethod
@@ -49,8 +58,15 @@ class GcpProjectUpdate(BaseModel):
     default_region: Optional[str] = None
     state_bucket: Optional[str] = None
     state_prefix: Optional[str] = None
+    # Send "" (or null) to clear back to the auto-derived colour.
+    color: Optional[str] = None
     # If provided, re-encrypted on the server.
     service_account_json: Optional[str] = None
+
+    @field_validator("color")
+    @classmethod
+    def _color(cls, v: Optional[str]) -> Optional[str]:
+        return account_colors.normalize(v)
 
     @field_validator("service_account_json")
     @classmethod
@@ -73,6 +89,12 @@ class GcpProjectResponse(BaseModel):
     default_region: str
     state_bucket: Optional[str] = None
     state_prefix: Optional[str] = None
+    # `color` is what's stored (None = auto, so Settings can show "Auto"
+    # selected); `color_effective` is what the UI actually paints and is
+    # always populated. Two fields so the derived-default hash lives in
+    # exactly one place — the server.
+    color: Optional[str] = None
+    color_effective: str = "gray"
     service_account_masked: str
 
     model_config = {"from_attributes": False}

--- a/services/api/app/services/account_colors.py
+++ b/services/api/app/services/account_colors.py
@@ -1,0 +1,166 @@
+"""Canonical colour palette for cloud accounts (AWS / Azure / GCP / K8s).
+
+Why a fixed palette instead of a free-form hex picker:
+
+  * The UI is theme-aware. A user-picked hex is illegible in one of the two
+    themes; a named token maps to a curated light/dark Tailwind pair (see
+    `services/ui/src/components/accountColors.ts`).
+  * `CLAUDE.md` forbids hard-coded colours in the frontend — tokens keep the
+    Tailwind-token rule intact.
+  * Slack needs a hex (attachment stripe) *and* an emoji (fallback text, where
+    attachments don't render). Slack only ships ~8 coloured-circle emoji, so the
+    palette is sized to 8 to keep UI ↔ Slack strictly 1:1.
+
+The TS side mirrors ORDER and token names; it does NOT reimplement the hash —
+the API always returns a resolved token so there is exactly one implementation
+of the fallback. Keep the two files in sync when adding a colour.
+"""
+from __future__ import annotations
+
+import hashlib
+from typing import Iterable, Optional
+
+# Ordered — the derived-default hash indexes into this tuple, so REORDERING
+# silently repaints every account that hasn't set an explicit colour. Append
+# only.
+ACCOUNT_COLORS: tuple[str, ...] = (
+    "red",
+    "orange",
+    "yellow",
+    "green",
+    "blue",
+    "purple",
+    "brown",
+    "gray",
+)
+
+# Slack attachment `color` — the vertical stripe on the left of a message.
+# Mid-tone hexes chosen to stay legible on both Slack themes.
+COLOR_HEX: dict[str, str] = {
+    "red": "#dc2626",
+    "orange": "#ea580c",
+    "yellow": "#ca8a04",
+    "green": "#059669",
+    "blue": "#2563eb",
+    "purple": "#7c3aed",
+    "brown": "#92400e",
+    "gray": "#64748b",
+}
+
+# Prefixed onto the Slack fallback `text` so mobile pushes and notification
+# previews — which render neither attachments nor blocks — still carry the cue.
+COLOR_EMOJI: dict[str, str] = {
+    "red": "🔴",
+    "orange": "🟠",
+    "yellow": "🟡",
+    "green": "🟢",
+    "blue": "🔵",
+    "purple": "🟣",
+    "brown": "🟤",
+    "gray": "⚪",
+}
+
+
+class InvalidAccountColor(ValueError):
+    """Raised for a colour token outside ACCOUNT_COLORS."""
+
+
+def normalize(value: Optional[str]) -> Optional[str]:
+    """Validate an incoming colour token from the API.
+
+    `None` and `""` both mean "auto" (fall back to the derived default) and
+    normalize to None so the column stores NULL rather than an empty string.
+    """
+    if value is None:
+        return None
+    v = value.strip().lower()
+    if not v:
+        return None
+    if v not in COLOR_HEX:
+        raise InvalidAccountColor(
+            f"color must be one of {', '.join(ACCOUNT_COLORS)} (got {value!r})"
+        )
+    return v
+
+
+def derive(key: str) -> str:
+    """Last-resort colour for a row with a NULL `color`.
+
+    Normally unreachable: the API assigns a distinct colour at creation (see
+    `pick_next`) and migration 041 backfilled every pre-existing row. This
+    covers rows inserted outside the API — seed scripts, direct SQL, a restored
+    dump.
+
+    sha256 rather than `hash()` because PYTHONHASHSEED randomizes str hashing
+    per process, which would repaint the Runs page on every API restart. Note
+    this can collide across accounts (8 buckets); `pick_next` is what actually
+    guarantees distinctness.
+    """
+    digest = hashlib.sha256((key or "").encode("utf-8")).digest()
+    return ACCOUNT_COLORS[int.from_bytes(digest[:4], "big") % len(ACCOUNT_COLORS)]
+
+
+def pick_next(taken: Iterable[Optional[str]]) -> str:
+    """First unused palette colour, so a new account never matches an existing
+    one while there are still free colours.
+
+    Past 8 accounts in a BU some reuse is unavoidable — then pick the
+    least-used colour (ties broken by palette order) so collisions spread
+    evenly instead of piling onto "red".
+    """
+    counts = {c: 0 for c in ACCOUNT_COLORS}
+    for t in taken:
+        if t in counts:
+            counts[t] += 1
+    return min(ACCOUNT_COLORS, key=lambda c: (counts[c], ACCOUNT_COLORS.index(c)))
+
+
+async def used_colors_for_bu(session, business_unit_id: Optional[str]) -> list[str]:
+    """Every colour already claimed by any cloud account in this BU.
+
+    Deliberately spans all four provider tables: the Runs page interleaves
+    Terraform (AWS/Azure/GCP) and Helm (K8s cluster) runs, so a colour reused
+    across providers is just as confusing as one reused within a provider.
+
+    Imports are local to keep this module import-safe from the schema layer.
+    """
+    from sqlalchemy import select
+
+    from app.models.aws_account import AwsAccount
+    from app.models.azure_subscription import AzureSubscription
+    from app.models.gcp_project import GcpProject
+    from app.models.k8s_cluster import K8sCluster
+
+    out: list[str] = []
+    for model in (AwsAccount, AzureSubscription, GcpProject, K8sCluster):
+        stmt = select(model.color).where(model.color.is_not(None))
+        if business_unit_id is not None:
+            stmt = stmt.where(model.business_unit_id == business_unit_id)
+        out.extend(c for c in (await session.execute(stmt)).scalars().all() if c)
+    return out
+
+
+async def assign_for_bu(session, business_unit_id: Optional[str], explicit: Optional[str]) -> str:
+    """Resolve the colour to persist on a newly-created cloud account.
+
+    An explicit choice always wins; otherwise claim the first free colour in
+    the BU. Called on create so the value is stored once and never shifts
+    afterwards — deriving at read time would let an unrelated account's
+    creation repaint existing rows.
+    """
+    if explicit:
+        return explicit
+    return pick_next(await used_colors_for_bu(session, business_unit_id))
+
+
+def effective(color: Optional[str], key: str) -> str:
+    """The token the UI/Slack should actually paint: explicit choice or derived."""
+    return color or derive(key)
+
+
+def slack_hex(color: Optional[str], key: str) -> str:
+    return COLOR_HEX[effective(color, key)]
+
+
+def slack_emoji(color: Optional[str], key: str) -> str:
+    return COLOR_EMOJI[effective(color, key)]

--- a/services/api/app/services/cluster_service.py
+++ b/services/api/app/services/cluster_service.py
@@ -152,6 +152,7 @@ async def create_cluster(
     server_url: str | None = None,
     default_namespace: str | None = None,
     aws_account_id: str | None = None,
+    color: str | None = None,
 ) -> K8sCluster:
     """Create and persist a new cluster, encrypting the kubeconfig at rest."""
     validate_kubeconfig(kubeconfig)
@@ -162,6 +163,7 @@ async def create_cluster(
         server_url=server_url,
         default_namespace=default_namespace,
         aws_account_id=(aws_account_id or None),
+        color=color,
         kubeconfig_encrypted=encrypt_secret(kubeconfig),
     )
     session.add(cluster)
@@ -181,6 +183,8 @@ async def update_cluster(
     kubeconfig: str | None = None,
     aws_account_id: str | None = None,
     aws_account_id_set: bool = False,
+    color: str | None = None,
+    color_set: bool = False,
 ) -> K8sCluster:
     """Apply partial updates. Re-encrypts the kubeconfig only when supplied.
 
@@ -197,6 +201,10 @@ async def update_cluster(
         cluster.default_namespace = default_namespace
     if aws_account_id_set:
         cluster.aws_account_id = (aws_account_id or None)
+    # Same set/clear distinction as aws_account_id: None means "back to the
+    # auto-derived colour", which is a real value the caller can send.
+    if color_set:
+        cluster.color = (color or None)
     if kubeconfig is not None:
         validate_kubeconfig(kubeconfig)
         cluster.kubeconfig_encrypted = encrypt_secret(kubeconfig)

--- a/services/api/app/services/notification_service.py
+++ b/services/api/app/services/notification_service.py
@@ -3,6 +3,7 @@ import email.message
 import logging
 import os
 import smtplib
+from typing import NamedTuple
 
 import httpx
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -28,8 +29,14 @@ async def send_plan_approval_notification(
     plan_summary: str,
     *,
     api_base_url: str | None = None,
+    workspace_id: str | None = None,
 ) -> None:
-    """POST Slack Block Kit message with plan excerpt and approve/reject links."""
+    """POST Slack Block Kit message with plan excerpt and approve/reject links.
+
+    `workspace_id` is optional only for back-compat with callers that predate
+    account colours; pass it whenever you have it so the message carries the
+    same account stripe / emoji as the bot-token path.
+    """
     url = await get_slack_webhook_url(session)
     # Prefer PUBLIC_UI_URL for the user-facing links; PUBLIC_API_URL is the
     # back-compat fallback for deployments where UI + API share a host.
@@ -40,37 +47,47 @@ async def send_plan_approval_notification(
         or "http://localhost:8000"
     ).rstrip("/")
     excerpt = (plan_summary or "")[:2000]
+    badge = await _account_badge(session, workspace_id) if workspace_id else _NO_ACCOUNT
 
     if url:
-        payload = {
-            "blocks": [
-                {
-                    "type": "header",
-                    "text": {"type": "plain_text", "text": f"Terraform plan ready: {workspace_name}"},
-                },
-                {
-                    "type": "section",
-                    "text": {"type": "mrkdwn", "text": f"```{excerpt}\n```"},
-                },
-                {
-                    "type": "actions",
-                    "elements": [
-                        {
-                            "type": "button",
-                            "text": {"type": "plain_text", "text": "Approve"},
-                            "style": "primary",
-                            "url": f"{base}/runs/{run_id}/approve",
-                        },
-                        {
-                            "type": "button",
-                            "text": {"type": "plain_text", "text": "Reject"},
-                            "style": "danger",
-                            "url": f"{base}/runs/{run_id}/reject",
-                        },
-                    ],
-                },
-            ]
-        }
+        blocks: list[dict] = [
+            {
+                "type": "header",
+                "text": {"type": "plain_text", "text": f"Terraform plan ready: {workspace_name}"},
+            },
+            {
+                "type": "section",
+                "text": {"type": "mrkdwn", "text": f"```{excerpt}\n```"},
+            },
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "Approve"},
+                        "style": "primary",
+                        "url": f"{base}/runs/{run_id}/approve",
+                    },
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "Reject"},
+                        "style": "danger",
+                        "url": f"{base}/runs/{run_id}/reject",
+                    },
+                ],
+            },
+        ]
+        if badge.label:
+            # Insert directly under the header, before the plan dump — an
+            # account line buried below 2000 chars of plan is useless.
+            blocks.insert(1, _fields_block([("Account", badge.label)]))
+        # Incoming webhooks previously sent `blocks` with no top-level `text`,
+        # which leaves mobile pushes blank. Always send one now.
+        payload = _stripe_payload(
+            text=f"{badge.emoji} Terraform plan ready: {workspace_name}".lstrip(),
+            blocks=blocks,
+            color=badge.hex,
+        )
         try:
             async with httpx.AsyncClient() as client:
                 await client.post(url, json=payload, timeout=30.0)
@@ -84,8 +101,9 @@ async def send_plan_approval_notification(
         session,
         subject=f"Terraform plan ready: {workspace_name}",
         body=(
-            f"Run {run_id} is awaiting approval for workspace '{workspace_name}'.\n\n"
-            f"Plan excerpt:\n{excerpt}\n\n"
+            f"Run {run_id} is awaiting approval for workspace '{workspace_name}'.\n"
+            + (f"Account: {badge.label.replace('`', '')}\n" if badge.label else "")
+            + f"\nPlan excerpt:\n{excerpt}\n\n"
             f"Approve: {base}/runs/{run_id}/approve\n"
             f"Reject:  {base}/runs/{run_id}/reject"
         ),
@@ -117,6 +135,8 @@ async def send_drift_alert(
     session: AsyncSession,
     workspace_name: str,
     summary: str,
+    *,
+    workspace_id: str | None = None,
 ) -> None:
     """Slack + email alert when drift is detected.
 
@@ -125,9 +145,13 @@ async def send_drift_alert(
     drift run as failed and skip subsequent workspaces).
     """
     url = await get_slack_webhook_url(session)
+    badge = await _account_badge(session, workspace_id) if workspace_id else _NO_ACCOUNT
     if url:
-        text = f"*Drift detected* — `{workspace_name}`\n{summary}"
-        payload = {"text": text, "blocks": [{"type": "section", "text": {"type": "mrkdwn", "text": text}}]}
+        text = f"{badge.emoji} *Drift detected* — `{workspace_name}`\n{summary}".lstrip()
+        blocks: list[dict] = [{"type": "section", "text": {"type": "mrkdwn", "text": text}}]
+        if badge.label:
+            blocks.append(_fields_block([("Account", badge.label)]))
+        payload = _stripe_payload(text=text, blocks=blocks, color=badge.hex)
         try:
             async with httpx.AsyncClient() as client:
                 await client.post(url, json=payload, timeout=30.0)
@@ -137,7 +161,11 @@ async def send_drift_alert(
     await send_email_notification(
         session,
         subject=f"Drift detected: {workspace_name}",
-        body=f"Drift was detected in workspace '{workspace_name}'.\n\nSummary:\n{summary}",
+        body=(
+            f"Drift was detected in workspace '{workspace_name}'.\n"
+            + (f"Account: {badge.label.replace('`', '')}\n" if badge.label else "")
+            + f"\nSummary:\n{summary}"
+        ),
     )
 
 
@@ -179,18 +207,109 @@ async def _resolve_bu_slug_for_workspace(
     return bu.slug if bu else None
 
 
+class _AccountBadge(NamedTuple):
+    """How a workspace's cloud account is presented in Slack."""
+
+    label: str  # e.g. "Prod-Account (444444444444)"
+    hex: str | None  # attachment stripe
+    emoji: str  # prefixed onto the fallback text
+
+
+# Badge for "no account to attribute" — an unresolvable workspace, or a legacy
+# caller that didn't pass a workspace_id. No stripe, no emoji, no Account field.
+_NO_ACCOUNT = _AccountBadge(label="", hex=None, emoji="")
+
+
+def _stripe_payload(*, text: str, blocks: list[dict], color: str | None) -> dict:
+    """Incoming-webhook payload, striped with the account colour when known.
+
+    Same shape decision as `slack.post_message`: a colour means the blocks move
+    inside one attachment (the only way Slack draws the left bar), and `text`
+    stays top-level either way so notification previews keep working.
+    """
+    if color:
+        return {"text": text, "attachments": [{"color": color, "blocks": blocks}]}
+    return {"text": text, "blocks": blocks}
+
+
+async def _account_badge(session: AsyncSession, workspace_id: str) -> _AccountBadge:
+    """Resolve the cloud account behind a workspace into a Slack badge.
+
+    Mirrors the Runs page rail: helm workspaces are attributed to their K8s
+    cluster, terraform workspaces to whichever cloud account their state
+    backend resolves through. A deleted or unregistered account degrades to a
+    bare id with no stripe rather than failing the notification.
+    """
+    from app.models.aws_account import AwsAccount
+    from app.models.azure_subscription import AzureSubscription
+    from app.models.gcp_project import GcpProject
+    from app.models.k8s_cluster import K8sCluster
+    from app.models.workspace import Workspace
+    from app.services import account_colors
+    from sqlalchemy import select
+
+    ws = await session.get(Workspace, workspace_id)
+    if ws is None:
+        return _AccountBadge(label="", hex=None, emoji="")
+
+    row = None
+    fallback = ""
+    if ws.kind == "helm" and ws.cluster_id:
+        row = await session.get(K8sCluster, ws.cluster_id)
+        fallback = ws.cluster_id
+    elif ws.azure_subscription_id:
+        row = await session.get(AzureSubscription, ws.azure_subscription_id)
+        fallback = ws.azure_subscription_id
+    elif ws.gcp_project_id:
+        row = await session.get(GcpProject, ws.gcp_project_id)
+        fallback = ws.gcp_project_id
+    elif ws.aws_account_id:
+        fallback = ws.aws_account_id
+        row = (
+            await session.execute(
+                select(AwsAccount).where(
+                    AwsAccount.account_id == ws.aws_account_id,
+                    AwsAccount.business_unit_id == ws.business_unit_id,
+                )
+            )
+        ).scalars().first()
+
+    if row is None:
+        # "global" is the sentinel for provider-less workspaces — showing it as
+        # an account would be misleading, so show nothing.
+        return _AccountBadge(
+            label="" if fallback in ("", "global") else f"`{fallback}`",
+            hex=None,
+            emoji="",
+        )
+
+    key = getattr(row, "account_id", None) or row.id
+    token = account_colors.effective(row.color, key)
+    natural = getattr(row, "account_id", None)
+    label = f"{row.name} (`{natural}`)" if natural else row.name
+    return _AccountBadge(
+        label=label,
+        hex=account_colors.COLOR_HEX[token],
+        emoji=account_colors.COLOR_EMOJI[token],
+    )
+
+
 async def send_slack_bot_notification(
     session: AsyncSession,
     *,
     bu_slug: str,
     text: str,
     blocks: list | None = None,
+    color: str | None = None,
 ) -> None:
     """Post to the BU's configured Slack channel via bot token.
 
     Silently no-ops when the BU has no Slack config. All errors are
     swallowed and logged — notification must never break the calling
     flow (run PATCH, drift detector, etc.).
+
+    `color` is the cloud account's hex (see `_account_badge`) and becomes the
+    message's left stripe.
     """
     from app.services import slack as slack_svc
 
@@ -198,7 +317,7 @@ async def send_slack_bot_notification(
     if not token or not channel:
         return
     try:
-        await slack_svc.post_message(token, channel, text, blocks=blocks)
+        await slack_svc.post_message(token, channel, text, blocks=blocks, color=color)
     except slack_svc.SlackError as e:
         logger.warning(
             "Slack post failed for BU %s (channel=%s): %s",
@@ -306,7 +425,8 @@ async def send_slack_run_auto_approved(
         return
     link = _run_link(run_id)
     leaf = _leaf_path(working_dir, region)
-    text = f"✅ Auto-approved — {workspace_name} (no changes; <{link}|view run>)"
+    badge = await _account_badge(session, workspace_id)
+    text = f"{badge.emoji} ✅ Auto-approved — {workspace_name} (no changes; <{link}|view run>)".lstrip()
     blocks: list[dict] = [
         {
             "type": "section",
@@ -320,6 +440,7 @@ async def send_slack_run_auto_approved(
         },
         _fields_block(
             [
+                ("Account", badge.label),
                 ("Workspace", workspace_name or ""),
                 ("Path", f"`{leaf}`" if leaf else ""),
                 ("Region", region or ""),
@@ -330,7 +451,9 @@ async def send_slack_run_auto_approved(
         ),
         _link_button_block("View run", link),
     ]
-    await send_slack_bot_notification(session, bu_slug=bu_slug, text=text, blocks=blocks)
+    await send_slack_bot_notification(
+        session, bu_slug=bu_slug, text=text, blocks=blocks, color=badge.hex
+    )
 
 
 async def send_slack_run_awaiting_approval(
@@ -355,8 +478,9 @@ async def send_slack_run_awaiting_approval(
     link = _run_link(run_id)
     leaf = _leaf_path(working_dir, region)
     plan = _plan_summary_str(add, change, destroy)
+    badge = await _account_badge(session, workspace_id)
     text = (
-        f"⏸ Awaiting approval — {workspace_name}"
+        f"{badge.emoji} ⏸ Awaiting approval — {workspace_name}".lstrip()
         + (f" · {plan}" if plan else "")
         + f" (<{link}|review>)"
     )
@@ -370,6 +494,7 @@ async def send_slack_run_awaiting_approval(
         },
         _fields_block(
             [
+                ("Account", badge.label),
                 ("Workspace", workspace_name or ""),
                 ("Path", f"`{leaf}`" if leaf else ""),
                 ("Region", region or ""),
@@ -381,7 +506,9 @@ async def send_slack_run_awaiting_approval(
         ),
         _link_button_block("Review run", link),
     ]
-    await send_slack_bot_notification(session, bu_slug=bu_slug, text=text, blocks=blocks)
+    await send_slack_bot_notification(
+        session, bu_slug=bu_slug, text=text, blocks=blocks, color=badge.hex
+    )
 
 
 async def send_slack_run_failed(
@@ -404,8 +531,9 @@ async def send_slack_run_failed(
         return
     link = _run_link(run_id)
     leaf = _leaf_path(working_dir, region)
+    badge = await _account_badge(session, workspace_id)
     text = (
-        f"❌ Run failed — {workspace_name} ({command})"
+        f"{badge.emoji} ❌ Run failed — {workspace_name} ({command})".lstrip()
         + (f" at {failed_stage}" if failed_stage else "")
         + f" (<{link}|view>)"
     )
@@ -419,6 +547,7 @@ async def send_slack_run_failed(
         },
         _fields_block(
             [
+                ("Account", badge.label),
                 ("Workspace", workspace_name or ""),
                 ("Path", f"`{leaf}`" if leaf else ""),
                 ("Region", region or ""),
@@ -434,7 +563,9 @@ async def send_slack_run_failed(
             {"type": "section", "text": {"type": "mrkdwn", "text": f"```{excerpt}```"}}
         )
     blocks.append(_link_button_block("View run", link))
-    await send_slack_bot_notification(session, bu_slug=bu_slug, text=text, blocks=blocks)
+    await send_slack_bot_notification(
+        session, bu_slug=bu_slug, text=text, blocks=blocks, color=badge.hex
+    )
 
 
 async def send_slack_drift_detected(
@@ -453,7 +584,8 @@ async def send_slack_drift_detected(
     excerpt = (summary or "")[:800].strip()
     leaf = _leaf_path(working_dir, region)
     link = _workspace_link(workspace_id)
-    text = f"⚠ Drift detected — {workspace_name} (<{link}|view>)"
+    badge = await _account_badge(session, workspace_id)
+    text = f"{badge.emoji} ⚠ Drift detected — {workspace_name} (<{link}|view>)".lstrip()
     blocks: list[dict] = [
         {
             "type": "section",
@@ -464,6 +596,7 @@ async def send_slack_drift_detected(
         },
         _fields_block(
             [
+                ("Account", badge.label),
                 ("Workspace", workspace_name or ""),
                 ("Path", f"`{leaf}`" if leaf else ""),
                 ("Region", region or ""),
@@ -475,7 +608,9 @@ async def send_slack_drift_detected(
             {"type": "section", "text": {"type": "mrkdwn", "text": f"```{excerpt}```"}}
         )
     blocks.append(_link_button_block("View workspace", link))
-    await send_slack_bot_notification(session, bu_slug=bu_slug, text=text, blocks=blocks)
+    await send_slack_bot_notification(
+        session, bu_slug=bu_slug, text=text, blocks=blocks, color=badge.hex
+    )
 
 
 async def send_email_notification(

--- a/services/api/app/services/slack.py
+++ b/services/api/app/services/slack.py
@@ -143,12 +143,30 @@ async def list_channels(token: str, limit: int = 1000) -> list[SlackChannel]:
     return out
 
 
-async def post_message(token: str, channel: str, text: str, blocks: list | None = None) -> None:
+async def post_message(
+    token: str,
+    channel: str,
+    text: str,
+    blocks: list | None = None,
+    color: str | None = None,
+) -> None:
     """Post a message to a channel. Raises SlackError on failure.
 
     Callers used in notification hooks should wrap this in try/except and
-    log — a transient Slack outage must not break the run loop."""
+    log — a transient Slack outage must not break the run loop.
+
+    `color` is a hex like "#2563eb" (see app.services.account_colors). When set,
+    the blocks move inside a single attachment so Slack draws its vertical
+    coloured bar down the left of the message — the same at-a-glance account cue
+    the Runs page paints as a row rail. Attachments are the only way to get that
+    stripe; Block Kit has no equivalent. The top-level `text` stays put either
+    way so mobile pushes and notification previews remain informative.
+    """
     payload: dict = {"channel": channel, "text": text}
-    if blocks:
+    if color and blocks:
+        payload["attachments"] = [{"color": color, "blocks": blocks}]
+    elif color:
+        payload["attachments"] = [{"color": color, "text": text}]
+    elif blocks:
         payload["blocks"] = blocks
     await _post(token, "chat.postMessage", payload)

--- a/services/api/tests/test_account_colors.py
+++ b/services/api/tests/test_account_colors.py
@@ -1,0 +1,154 @@
+"""Cloud-account colour labels: palette helpers + the API contract around them.
+
+The point of the feature is that two accounts never look alike on the Runs page,
+so most of these assert distinctness rather than specific colours.
+"""
+import pytest
+
+from app.services import account_colors as ac
+
+pytestmark = pytest.mark.usefixtures("default_bu")
+
+
+def _h(token, bu="default"):
+    return {"Authorization": f"Bearer {token}", "X-Business-Unit": bu}
+
+
+def _body(account_id="111111111111", **over):
+    b = {
+        "account_id": account_id,
+        "name": f"acct-{account_id}",
+        "state_bucket": f"bkt-{account_id}",
+        "access_key_id": "AKIAEXAMPLE123",
+        "secret_access_key": "secret",
+    }
+    b.update(over)
+    return b
+
+
+# ─── palette helpers ─────────────────────────────────────────────────────────
+
+
+def test_palette_and_slack_tables_agree():
+    # Slack needs a hex and an emoji for every token; a token missing from
+    # either map would KeyError at notification time, not at import time.
+    assert set(ac.COLOR_HEX) == set(ac.ACCOUNT_COLORS)
+    assert set(ac.COLOR_EMOJI) == set(ac.ACCOUNT_COLORS)
+    assert len(set(ac.COLOR_HEX.values())) == len(ac.ACCOUNT_COLORS)
+
+
+def test_normalize_accepts_palette_and_clears_empty():
+    assert ac.normalize("blue") == "blue"
+    assert ac.normalize(" Blue ") == "blue"
+    # "" and None both mean auto → NULL, not an empty-string colour.
+    assert ac.normalize("") is None
+    assert ac.normalize(None) is None
+
+
+def test_normalize_rejects_unknown():
+    # Teal in particular: `sky` is aliased to brand teal, so a teal account
+    # colour would read as chrome. It must not be quietly accepted.
+    for bad in ("teal", "#ff0000", "RED!"):
+        with pytest.raises(ValueError):
+            ac.normalize(bad)
+
+
+def test_derive_is_stable_across_processes():
+    # sha256, not hash() — PYTHONHASHSEED would otherwise repaint every run row
+    # on each API restart.
+    assert ac.derive("444444444444") == ac.derive("444444444444")
+    assert ac.derive("444444444444") in ac.ACCOUNT_COLORS
+
+
+def test_pick_next_avoids_taken_then_spreads():
+    assert ac.pick_next([]) == ac.ACCOUNT_COLORS[0]
+    assert ac.pick_next(["red"]) == "orange"
+    # Every colour used once → reuse the least-used, not always the first.
+    assert ac.pick_next(list(ac.ACCOUNT_COLORS) + ["red"]) == "orange"
+    # Unknown/None entries in the taken list are ignored, not crashed on.
+    assert ac.pick_next([None, "not-a-colour"]) == ac.ACCOUNT_COLORS[0]
+
+
+def test_effective_prefers_explicit_choice():
+    assert ac.effective("purple", "444444444444") == "purple"
+    assert ac.effective(None, "444444444444") == ac.derive("444444444444")
+
+
+# ─── API contract ────────────────────────────────────────────────────────────
+
+
+async def test_created_accounts_get_distinct_colors(auth_client, admin_token):
+    """The headline guarantee: no two accounts in a BU share a colour."""
+    seen = []
+    for i in range(4):
+        r = await auth_client.post(
+            "/api/v1/aws-accounts",
+            json=_body(account_id=f"{i}" * 12),
+            headers=_h(admin_token),
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["color_effective"] == body["color"]
+        seen.append(body["color"])
+    assert len(set(seen)) == len(seen), seen
+
+
+async def test_explicit_color_round_trips(auth_client, admin_token):
+    r = await auth_client.post(
+        "/api/v1/aws-accounts",
+        json=_body(account_id="555555555555", color="purple"),
+        headers=_h(admin_token),
+    )
+    assert r.status_code == 201 and r.json()["color"] == "purple"
+
+    upd = await auth_client.put(
+        f"/api/v1/aws-accounts/{r.json()['id']}",
+        json={"color": "green"},
+        headers=_h(admin_token),
+    )
+    assert upd.status_code == 200 and upd.json()["color"] == "green"
+
+
+async def test_clearing_color_falls_back_to_derived(auth_client, admin_token):
+    r = await auth_client.post(
+        "/api/v1/aws-accounts",
+        json=_body(account_id="666666666666", color="purple"),
+        headers=_h(admin_token),
+    )
+    upd = await auth_client.put(
+        f"/api/v1/aws-accounts/{r.json()['id']}",
+        json={"color": ""},
+        headers=_h(admin_token),
+    )
+    assert upd.status_code == 200
+    # Stored NULL, but the UI still gets something to paint.
+    assert upd.json()["color"] is None
+    assert upd.json()["color_effective"] == ac.derive("666666666666")
+
+
+async def test_invalid_color_is_rejected(auth_client, admin_token):
+    r = await auth_client.post(
+        "/api/v1/aws-accounts",
+        json=_body(account_id="777777777777", color="teal"),
+        headers=_h(admin_token),
+    )
+    assert r.status_code == 422
+
+
+async def test_color_survives_an_unrelated_update(auth_client, admin_token):
+    """A PUT that doesn't mention `color` must not clear it.
+
+    `exclude_unset` is what makes this work; a plain model_dump would send
+    color=None on every rename.
+    """
+    r = await auth_client.post(
+        "/api/v1/aws-accounts",
+        json=_body(account_id="888888888888", color="brown"),
+        headers=_h(admin_token),
+    )
+    upd = await auth_client.put(
+        f"/api/v1/aws-accounts/{r.json()['id']}",
+        json={"name": "renamed"},
+        headers=_h(admin_token),
+    )
+    assert upd.status_code == 200 and upd.json()["color"] == "brown"

--- a/services/api/tests/test_notification_service.py
+++ b/services/api/tests/test_notification_service.py
@@ -135,6 +135,97 @@ async def test_drift_alert_slack_and_email(db_session, fake_http):
     await ns.send_drift_alert(db_session, "ws", "x")
 
 
+# ─── account colour on the legacy webhook path ───────────────────────────────
+
+
+async def _ws_with_account(db_session, color="purple"):
+    """A workspace whose AWS account is registered, so a badge resolves."""
+    from app.models.aws_account import AwsAccount
+    from app.services import aws_account_service as accs
+
+    ws = await _make_ws(db_session, name="coloured-ws")
+    db_session.add(
+        AwsAccount(
+            business_unit_id=DEFAULT_BU_ID,
+            account_id=ws.aws_account_id,
+            name="Prod-Account",
+            state_bucket="b",
+            state_bucket_region="us-east-1",
+            default_region="us-east-1",
+            color=color,
+            access_key_id_encrypted=accs.encrypt_secret("AKIAX"),
+            secret_access_key_encrypted=accs.encrypt_secret("s"),
+        )
+    )
+    await db_session.commit()
+    return ws
+
+
+async def test_plan_approval_carries_account_stripe(db_session, fake_http):
+    ws = await _ws_with_account(db_session)
+    await _set(db_session, "slack.webhook_url", "https://hooks/ok")
+    await ns.send_plan_approval_notification(
+        db_session, "run1", "ws", "PLAN", workspace_id=ws.id
+    )
+    _, body = fake_http.last_posts[-1]
+    # Blocks move inside one attachment — that's what draws Slack's left bar.
+    assert body["attachments"][0]["color"] == "#7c3aed"
+    assert "blocks" not in body
+    # Top-level text (with the emoji) so mobile pushes aren't blank.
+    assert body["text"].startswith("\U0001f7e3 ")
+    # Account sits directly under the header, above the plan dump.
+    blocks = body["attachments"][0]["blocks"]
+    assert blocks[0]["type"] == "header"
+    assert "Prod-Account" in blocks[1]["fields"][0]["text"]
+
+
+async def test_drift_alert_carries_account_stripe(db_session, fake_http):
+    ws = await _ws_with_account(db_session, color="green")
+    await _set(db_session, "slack.webhook_url", "https://hooks/ok")
+    await ns.send_drift_alert(db_session, "ws", "changed", workspace_id=ws.id)
+    _, body = fake_http.last_posts[-1]
+    assert body["attachments"][0]["color"] == "#059669"
+    assert body["text"].startswith("\U0001f7e2 ")
+
+
+async def test_legacy_senders_without_workspace_id_are_unstriped(db_session, fake_http):
+    """Back-compat: a caller that passes no workspace_id still posts, plainly."""
+    await _set(db_session, "slack.webhook_url", "https://hooks/ok")
+    await ns.send_drift_alert(db_session, "ws", "changed")
+    _, body = fake_http.last_posts[-1]
+    assert "attachments" not in body
+    assert body["blocks"]
+    assert not body["text"].startswith(" ")
+
+
+async def test_unregistered_account_gets_no_stripe(db_session, fake_http):
+    """A workspace whose account isn't in aws_accounts must not invent a colour."""
+    ws = await _make_ws(db_session, name="orphan-ws")
+    await _set(db_session, "slack.webhook_url", "https://hooks/ok")
+    await ns.send_drift_alert(db_session, "ws", "changed", workspace_id=ws.id)
+    _, body = fake_http.last_posts[-1]
+    assert "attachments" not in body
+
+
+async def test_email_names_the_account(db_session, monkeypatch):
+    """Slack and email must not disagree about which account is affected."""
+    ws = await _ws_with_account(db_session)
+    bodies = []
+    monkeypatch.setattr(
+        ns,
+        "send_email_notification",
+        lambda session, *, subject, body: bodies.append(body) or _noop(),
+    )
+    await ns.send_drift_alert(db_session, "ws", "changed", workspace_id=ws.id)
+    # Plaintext, so the Slack mrkdwn backticks are stripped.
+    assert "Account: Prod-Account (123456789012)" in bodies[0]
+    assert "`" not in bodies[0]
+
+
+async def _noop():
+    return None
+
+
 async def test_email_paths(db_session, monkeypatch):
     sent = {}
 
@@ -271,7 +362,7 @@ async def test_send_slack_bot_notification_paths(db_session, monkeypatch):
 
     calls = []
 
-    async def ok(token, channel, text, blocks=None):
+    async def ok(token, channel, text, blocks=None, color=None):
         calls.append((token, channel))
 
     monkeypatch.setattr(slack_svc, "post_message", ok)
@@ -299,7 +390,7 @@ async def test_run_event_builders_resolve_and_skip(db_session, monkeypatch):
     ws = await _make_ws(db_session)
     posted = []
 
-    async def rec(session, *, bu_slug, text, blocks=None):
+    async def rec(session, *, bu_slug, text, blocks=None, color=None):
         posted.append(text)
 
     monkeypatch.setattr(ns, "send_slack_bot_notification", rec)

--- a/services/api/tests/test_pure_services.py
+++ b/services/api/tests/test_pure_services.py
@@ -224,6 +224,20 @@ async def test_post_message_with_and_without_blocks(monkeypatch):
     assert "blocks" not in seen[0]
     assert seen[1]["blocks"] == [{"type": "section"}]
 
+    # With a colour the blocks move inside a single attachment — that's what
+    # draws Slack's left stripe. `text` stays top-level either way so mobile
+    # pushes (which render neither) keep working.
+    await slack.post_message("t", "C1", "hi", blocks=[{"type": "section"}], color="#2563eb")
+    assert "blocks" not in seen[2]
+    assert seen[2]["attachments"] == [
+        {"color": "#2563eb", "blocks": [{"type": "section"}]}
+    ]
+    assert seen[2]["text"] == "hi"
+
+    # Colour with no blocks still gets a stripe.
+    await slack.post_message("t", "C1", "hi", color="#dc2626")
+    assert seen[3]["attachments"] == [{"color": "#dc2626", "text": "hi"}]
+
 
 def test_slackerror_message_defaults_to_code():
     assert str(slack.SlackError("rate_limited")) == "rate_limited"

--- a/services/api/tests/test_small_routers.py
+++ b/services/api/tests/test_small_routers.py
@@ -240,8 +240,9 @@ async def test_drift_scan_and_report(auth_client, admin_token, _setup_db, monkey
     # drifted report → triggers the alert hook (mocked)
     sent = {}
 
-    async def fake_alert(db, name, summary):
+    async def fake_alert(db, name, summary, *, workspace_id=None):
         sent["name"] = name
+        sent["workspace_id"] = workspace_id
 
     monkeypatch.setattr("app.routers.drift.send_drift_alert", fake_alert)
     drifted = await auth_client.post(
@@ -250,6 +251,9 @@ async def test_drift_scan_and_report(auth_client, admin_token, _setup_db, monkey
         headers=_h(admin_token),
     )
     assert drifted.json()["has_drift"] is True and sent["name"] == "drift-ws"
+    # The router must forward the workspace so the alert can resolve the
+    # account's colour/stripe.
+    assert sent["workspace_id"] == ws_id
 
 
 # ─── audit ───────────────────────────────────────────────────────────────────

--- a/services/ui/src/components/AccountTag.tsx
+++ b/services/ui/src/components/AccountTag.tsx
@@ -1,0 +1,105 @@
+import {
+  ACCOUNT_COLOR_CLASSES,
+  ACCOUNT_COLOR_LABELS,
+  ACCOUNT_COLORS,
+  asAccountColor,
+  type AccountColor,
+} from "./accountColors";
+import { cx } from "./ui";
+
+/**
+ * A cloud account rendered as `● Account-Name`, with the raw id in the tooltip.
+ *
+ * The name carries the meaning and the dot carries the colour: colour is never
+ * the only channel, so the row still reads for colourblind users and in
+ * grayscale print. The 12-digit id moves to `title` because nobody recognises
+ * an account by its number.
+ */
+export function AccountTag({
+  color,
+  name,
+  id,
+  className,
+}: {
+  color: string | null | undefined;
+  name: string;
+  /** Natural id (12-digit AWS account, subscription/project id, cluster PK). */
+  id?: string;
+  className?: string;
+}) {
+  const token = asAccountColor(color);
+  return (
+    <span
+      className={cx("inline-flex items-center gap-1.5", className)}
+      title={id ? `${name} · ${id}` : name}
+    >
+      <span
+        aria-hidden
+        className={cx("h-2 w-2 shrink-0 rounded-full", ACCOUNT_COLOR_CLASSES[token].solid)}
+      />
+      <span className="truncate">{name}</span>
+    </span>
+  );
+}
+
+/**
+ * The 3px colour rail down the left of a Runs row. Rendered as a sibling
+ * absolute element rather than a `border-l` so it butts flush against the card
+ * edge and doesn't shift the row's content by a pixel when absent.
+ */
+export function AccountRail({ color }: { color: string | null | undefined }) {
+  return (
+    <span
+      aria-hidden
+      className={cx(
+        "absolute inset-y-0 left-0 w-[3px]",
+        ACCOUNT_COLOR_CLASSES[asAccountColor(color)].solid,
+      )}
+    />
+  );
+}
+
+/**
+ * Swatch radio-group for Settings. Eight fixed choices — see accountColors.ts
+ * for why this isn't an `<input type="color">`.
+ */
+export function AccountColorPicker({
+  value,
+  onChange,
+  disabled,
+}: {
+  value: string | null | undefined;
+  onChange: (color: AccountColor) => void;
+  disabled?: boolean;
+}) {
+  const selected = asAccountColor(value);
+  return (
+    <div className="flex flex-wrap items-center gap-1.5" role="radiogroup" aria-label="Account color">
+      {ACCOUNT_COLORS.map((c) => {
+        const isOn = c === selected;
+        return (
+          <button
+            key={c}
+            type="button"
+            role="radio"
+            aria-checked={isOn}
+            aria-label={ACCOUNT_COLOR_LABELS[c]}
+            title={ACCOUNT_COLOR_LABELS[c]}
+            disabled={disabled}
+            onClick={() => onChange(c)}
+            className={cx(
+              "h-6 w-6 rounded-full transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-1",
+              ACCOUNT_COLOR_CLASSES[c].swatch,
+              // A ring rather than a checkmark: at 24px a glyph on a saturated
+              // fill is unreadable in half the palette.
+              isOn
+                ? "ring-2 ring-slate-900 ring-offset-2 ring-offset-white dark:ring-white dark:ring-offset-slate-900"
+                : "opacity-70 hover:opacity-100",
+              disabled && "cursor-not-allowed opacity-40",
+            )}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/services/ui/src/components/accountColors.ts
+++ b/services/ui/src/components/accountColors.ts
@@ -1,0 +1,113 @@
+/**
+ * Cloud-account colour palette — the frontend half of
+ * `services/api/app/services/account_colors.py`. Token names and ORDER must
+ * match that file.
+ *
+ * Class strings are written out literally rather than composed (`bg-${hue}-500`)
+ * because Tailwind's scanner only emits classes it can see in the source. Each
+ * token carries a light/dark pair so a colour stays legible in both themes —
+ * the reason accounts pick a token here instead of a raw hex.
+ *
+ * Note: no teal. Tailwind's `sky` is aliased to brand teal in this repo (see
+ * docs/claude/design.md), so a teal account colour would read as chrome rather
+ * than as data.
+ */
+export type AccountColor =
+  | "red"
+  | "orange"
+  | "yellow"
+  | "green"
+  | "blue"
+  | "purple"
+  | "brown"
+  | "gray";
+
+export const ACCOUNT_COLORS: AccountColor[] = [
+  "red",
+  "orange",
+  "yellow",
+  "green",
+  "blue",
+  "purple",
+  "brown",
+  "gray",
+];
+
+type ColorClasses = {
+  /** Vertical rail down the left of a Runs row, and the dot on the mono line. */
+  solid: string;
+  /** Filled swatch for the Settings picker (no dark variant — it's the colour itself). */
+  swatch: string;
+  /** Tinted pill, for previewing the colour next to an account name. */
+  chip: string;
+};
+
+export const ACCOUNT_COLOR_CLASSES: Record<AccountColor, ColorClasses> = {
+  red: {
+    solid: "bg-red-500 dark:bg-red-400",
+    swatch: "bg-red-500",
+    chip: "bg-red-50 text-red-700 ring-red-300/60 dark:bg-red-900/40 dark:text-red-300 dark:ring-red-700/40",
+  },
+  orange: {
+    solid: "bg-orange-500 dark:bg-orange-400",
+    swatch: "bg-orange-500",
+    chip: "bg-orange-50 text-orange-700 ring-orange-300/60 dark:bg-orange-900/40 dark:text-orange-300 dark:ring-orange-700/40",
+  },
+  yellow: {
+    solid: "bg-yellow-500 dark:bg-yellow-400",
+    swatch: "bg-yellow-500",
+    chip: "bg-yellow-50 text-yellow-800 ring-yellow-300/60 dark:bg-yellow-900/40 dark:text-yellow-300 dark:ring-yellow-700/40",
+  },
+  green: {
+    solid: "bg-emerald-500 dark:bg-emerald-400",
+    swatch: "bg-emerald-500",
+    chip: "bg-emerald-50 text-emerald-700 ring-emerald-300/60 dark:bg-emerald-900/40 dark:text-emerald-300 dark:ring-emerald-700/40",
+  },
+  blue: {
+    solid: "bg-blue-500 dark:bg-blue-400",
+    swatch: "bg-blue-500",
+    chip: "bg-blue-50 text-blue-700 ring-blue-300/60 dark:bg-blue-900/40 dark:text-blue-300 dark:ring-blue-700/40",
+  },
+  purple: {
+    solid: "bg-violet-500 dark:bg-violet-400",
+    swatch: "bg-violet-500",
+    chip: "bg-violet-50 text-violet-700 ring-violet-300/60 dark:bg-violet-900/40 dark:text-violet-300 dark:ring-violet-700/40",
+  },
+  brown: {
+    solid: "bg-amber-700 dark:bg-amber-600",
+    swatch: "bg-amber-700",
+    chip: "bg-amber-50 text-amber-800 ring-amber-400/60 dark:bg-amber-900/40 dark:text-amber-300 dark:ring-amber-700/40",
+  },
+  gray: {
+    solid: "bg-slate-400 dark:bg-slate-500",
+    swatch: "bg-slate-400",
+    chip: "bg-slate-100 text-slate-700 ring-slate-300/80 dark:bg-slate-800/80 dark:text-slate-300 dark:ring-slate-700/50",
+  },
+};
+
+/** Human label for the picker's tooltip / aria-label. */
+export const ACCOUNT_COLOR_LABELS: Record<AccountColor, string> = {
+  red: "Red",
+  orange: "Orange",
+  yellow: "Yellow",
+  green: "Green",
+  blue: "Blue",
+  purple: "Purple",
+  brown: "Brown",
+  gray: "Gray",
+};
+
+/**
+ * Narrow an API `color_effective` string to a token.
+ *
+ * The API always sends a valid one; this guards against an older API (before
+ * migration 041) omitting the field, in which case everything renders gray
+ * rather than crashing on an undefined class lookup.
+ */
+export function asAccountColor(value: string | null | undefined): AccountColor {
+  return value && value in ACCOUNT_COLOR_CLASSES ? (value as AccountColor) : "gray";
+}
+
+export function accountRailClass(value: string | null | undefined): string {
+  return ACCOUNT_COLOR_CLASSES[asAccountColor(value)].solid;
+}

--- a/services/ui/src/hooks/useAccountColors.test.ts
+++ b/services/ui/src/hooks/useAccountColors.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+import {
+  asAccountColor,
+  accountRailClass,
+  ACCOUNT_COLORS,
+  ACCOUNT_COLOR_CLASSES,
+} from "../components/accountColors";
+
+const get = vi.fn();
+vi.mock("../api/client", () => ({ api: { get: (...a: unknown[]) => get(...a) } }));
+
+import { useAccountColors } from "./useAccountColors";
+
+const AWS = [
+  { id: "pk-1", account_id: "333333333333", name: "Prod-Account", color_effective: "red" },
+];
+const K8S = [{ id: "cl-1", name: "prod-eks", color_effective: "yellow" }];
+
+beforeEach(() => {
+  get.mockReset();
+  get.mockImplementation((url: string) => {
+    if (url.includes("aws-accounts")) return Promise.resolve({ data: AWS });
+    if (url.includes("clusters")) return Promise.resolve({ data: K8S });
+    return Promise.resolve({ data: [] });
+  });
+});
+
+describe("palette helpers", () => {
+  it("every token has classes", () => {
+    for (const c of ACCOUNT_COLORS) {
+      expect(ACCOUNT_COLOR_CLASSES[c].solid).toBeTruthy();
+      expect(ACCOUNT_COLOR_CLASSES[c].swatch).toBeTruthy();
+      expect(ACCOUNT_COLOR_CLASSES[c].chip).toBeTruthy();
+    }
+  });
+
+  it("falls back to gray rather than crashing on an unknown/absent colour", () => {
+    // Guards against an API older than migration 041 omitting the field — an
+    // undefined class lookup would otherwise throw while rendering every row.
+    expect(asAccountColor(undefined)).toBe("gray");
+    expect(asAccountColor(null)).toBe("gray");
+    expect(asAccountColor("chartreuse")).toBe("gray");
+    expect(accountRailClass("chartreuse")).toContain("slate");
+  });
+
+  it("passes through a valid token", () => {
+    expect(asAccountColor("purple")).toBe("purple");
+    expect(accountRailClass("purple")).toContain("violet");
+  });
+});
+
+describe("useAccountColors badgeFor", () => {
+  async function badges() {
+    const { result } = renderHook(() => useAccountColors());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    return result.current.badgeFor;
+  }
+
+  it("keys AWS by the 12-digit account id, not the row PK", async () => {
+    const badgeFor = await badges();
+    const b = badgeFor({ aws_account_id: "333333333333" });
+    expect(b).toMatchObject({ color: "red", name: "Prod-Account", id: "333333333333" });
+    // The PK must NOT resolve — workspaces store the 12-digit id.
+    expect(badgeFor({ aws_account_id: "pk-1" })).toBeNull();
+  });
+
+  it("attributes helm workspaces to their cluster", async () => {
+    const badgeFor = await badges();
+    const b = badgeFor({ kind: "helm", cluster_id: "cl-1", aws_account_id: "333333333333" });
+    // Cluster wins over the AWS account for helm — matching the Slack resolver.
+    expect(b).toMatchObject({ color: "yellow", name: "prod-eks" });
+  });
+
+  it("treats the 'global' sentinel and unknown accounts as no account", async () => {
+    const badgeFor = await badges();
+    expect(badgeFor({ aws_account_id: "global" })).toBeNull();
+    expect(badgeFor({ aws_account_id: "999999999999" })).toBeNull();
+    expect(badgeFor(undefined)).toBeNull();
+  });
+
+  it("survives a provider endpoint failing", async () => {
+    get.mockImplementation((url: string) => {
+      if (url.includes("aws-accounts")) return Promise.resolve({ data: AWS });
+      return Promise.reject(new Error("403"));
+    });
+    const badgeFor = await badges();
+    // AWS colours still resolve even though the other three 403'd.
+    expect(badgeFor({ aws_account_id: "333333333333" })?.color).toBe("red");
+    expect(badgeFor({ kind: "helm", cluster_id: "cl-1" })).toBeNull();
+  });
+});

--- a/services/ui/src/hooks/useAccountColors.ts
+++ b/services/ui/src/hooks/useAccountColors.ts
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { api } from "../api/client";
+import type { AccountColor } from "../components/accountColors";
+import { asAccountColor } from "../components/accountColors";
+import { BU_CHANGED_EVENT } from "./useBusinessUnit";
+
+/**
+ * Resolves the cloud account behind a workspace so run rows can be colour-coded
+ * and labelled by account instead of by bare 12-digit id.
+ *
+ * All four provider lists are readable by `viewer` and return no secrets, so
+ * this works for every role. They're fetched once (not on the Runs page's 8s
+ * poll) — accounts change on the order of months, runs on the order of seconds.
+ */
+
+/** What a run row needs to render an account: a name, an id, and a colour. */
+export type AccountBadge = {
+  color: AccountColor;
+  /** Display name, e.g. "Prod-Account". */
+  name: string;
+  /** Natural id — the 12-digit AWS account, subscription/project id, or cluster PK. */
+  id: string;
+};
+
+/** The workspace fields this resolver keys off; a subset of WorkspaceResponse. */
+export type WorkspaceLike = {
+  kind?: string;
+  aws_account_id?: string | null;
+  azure_subscription_id?: string | null;
+  gcp_project_id?: string | null;
+  cluster_id?: string | null;
+};
+
+type Maps = {
+  aws: Record<string, AccountBadge>;
+  azure: Record<string, AccountBadge>;
+  gcp: Record<string, AccountBadge>;
+  k8s: Record<string, AccountBadge>;
+};
+
+const EMPTY: Maps = { aws: {}, azure: {}, gcp: {}, k8s: {} };
+
+export function useAccountColors(): {
+  /** null when the workspace has no attributable account (or it was deleted). */
+  badgeFor: (ws: WorkspaceLike | undefined) => AccountBadge | null;
+  loading: boolean;
+} {
+  const [maps, setMaps] = useState<Maps>(EMPTY);
+  const [loading, setLoading] = useState(true);
+  // Bumped on a BU switch to force a refetch. The switcher doesn't reload the
+  // page, so without this the maps would keep the previous BU's accounts and
+  // every row in the new BU would fall back to a bare account id.
+  const [epoch, setEpoch] = useState(0);
+
+  useEffect(() => {
+    const bump = () => setEpoch((n) => n + 1);
+    window.addEventListener(BU_CHANGED_EVENT, bump);
+    // "storage" covers a BU switched in another tab.
+    window.addEventListener("storage", bump);
+    return () => {
+      window.removeEventListener(BU_CHANGED_EVENT, bump);
+      window.removeEventListener("storage", bump);
+    };
+  }, []);
+
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      // A provider the deployment doesn't use 404s/403s or returns [] — each
+      // call degrades to an empty map independently so one missing provider
+      // never costs the others their colours.
+      const empty = { data: [] as any[] };
+      const [aws, azure, gcp, k8s] = await Promise.all([
+        api.get("/v1/aws-accounts").catch(() => empty),
+        api.get("/v1/azure-subscriptions").catch(() => empty),
+        api.get("/v1/gcp-projects").catch(() => empty),
+        api.get("/v1/clusters").catch(() => empty),
+      ]);
+      if (!alive) return;
+      const build = (rows: any[], key: (r: any) => string): Record<string, AccountBadge> => {
+        const out: Record<string, AccountBadge> = {};
+        for (const r of rows ?? []) {
+          out[key(r)] = {
+            color: asAccountColor(r.color_effective ?? r.color),
+            name: r.name ?? "",
+            id: key(r),
+          };
+        }
+        return out;
+      };
+      setMaps({
+        // AWS is keyed by the 12-digit account id because that's what
+        // `workspace.aws_account_id` stores — not the row PK, unlike the others.
+        aws: build(aws.data, (r) => r.account_id),
+        azure: build(azure.data, (r) => r.id),
+        gcp: build(gcp.data, (r) => r.id),
+        k8s: build(k8s.data, (r) => r.id),
+      });
+      setLoading(false);
+    })();
+    return () => {
+      alive = false;
+    };
+  }, [epoch]);
+
+  const badgeFor = useCallback(
+    (ws: WorkspaceLike | undefined): AccountBadge | null => {
+      if (!ws) return null;
+      // Order mirrors notification_service._account_badge so a run's colour is
+      // the same in the UI and in Slack.
+      if (ws.kind === "helm" && ws.cluster_id) return maps.k8s[ws.cluster_id] ?? null;
+      if (ws.azure_subscription_id) return maps.azure[ws.azure_subscription_id] ?? null;
+      if (ws.gcp_project_id) return maps.gcp[ws.gcp_project_id] ?? null;
+      // "global" is the sentinel for provider-less workspaces — not an account.
+      if (ws.aws_account_id && ws.aws_account_id !== "global") {
+        return maps.aws[ws.aws_account_id] ?? null;
+      }
+      return null;
+    },
+    [maps],
+  );
+
+  return { badgeFor, loading };
+}

--- a/services/ui/src/hooks/useBusinessUnit.ts
+++ b/services/ui/src/hooks/useBusinessUnit.ts
@@ -7,7 +7,9 @@ import {
 } from "../api/businessUnits";
 import { getCurrentBusinessUnit, setCurrentBusinessUnit } from "../api/client";
 
-const BU_CHANGED_EVENT = "terraducktel:bu-changed";
+// Dispatched by setCurrentBusinessUnit in api/client.ts. Exported so any hook
+// holding BU-scoped data can refetch on a switch (there is no page reload).
+export const BU_CHANGED_EVENT = "terraducktel:bu-changed";
 
 /**
  * Current Business Unit selection — backed by localStorage.

--- a/services/ui/src/pages/AwsAccounts.tsx
+++ b/services/ui/src/pages/AwsAccounts.tsx
@@ -15,6 +15,8 @@ import {
   Skeleton,
   Spinner,
 } from "../components/ui";
+import { AccountColorPicker } from "../components/AccountTag";
+import { ACCOUNT_COLOR_CLASSES, asAccountColor } from "../components/accountColors";
 
 type AwsAccount = {
   id: string;
@@ -25,6 +27,9 @@ type AwsAccount = {
   state_bucket_region: string;
   default_region: string;
   aws_profile_name?: string | null;
+  // Stored choice (null = auto) vs. what to paint. See accountColors.ts.
+  color?: string | null;
+  color_effective?: string;
   access_key_id_masked: string;
 };
 
@@ -36,6 +41,7 @@ type FormState = {
   state_bucket_region: string;
   default_region: string;
   aws_profile_name: string;
+  color: string;
   access_key_id: string;
   secret_access_key: string;
 };
@@ -48,6 +54,9 @@ const EMPTY: FormState = {
   state_bucket_region: "us-east-1",
   default_region: "us-east-1",
   aws_profile_name: "",
+  // Left blank on create so the API claims the first colour unused in this BU;
+  // touching the picker replaces it with an explicit choice.
+  color: "",
   access_key_id: "",
   secret_access_key: "",
 };
@@ -113,6 +122,17 @@ function AccountForm({
                 onChange={(e) => update("description", e.target.value)}
                 placeholder="Production AWS account"
               />
+            </div>
+            <div className="sm:col-span-2">
+              <Label>Color</Label>
+              <AccountColorPicker value={f.color} onChange={(c) => update("color", c)} />
+              <p className="mt-1 text-xs text-slate-500">
+                Tags this account across the Runs page and Slack alerts so a run
+                is attributable at a glance.{" "}
+                {editing
+                  ? "Colors are unique per business unit unless you reuse one deliberately."
+                  : "Leave untouched to get the first color not already used in this business unit."}
+              </p>
             </div>
             <div>
               <Label>State S3 bucket</Label>
@@ -241,6 +261,8 @@ export default function AwsAccounts() {
         state_bucket_region: f.state_bucket_region,
         default_region: f.default_region,
         aws_profile_name: f.aws_profile_name || null,
+        // undefined (not null) so the API auto-assigns rather than storing NULL.
+        color: f.color || undefined,
         access_key_id: f.access_key_id,
         secret_access_key: f.secret_access_key,
       });
@@ -266,6 +288,7 @@ export default function AwsAccounts() {
         default_region: f.default_region,
         aws_profile_name: f.aws_profile_name || null,
       };
+      if (f.color) body.color = f.color;
       if (f.access_key_id) body.access_key_id = f.access_key_id;
       if (f.secret_access_key) body.secret_access_key = f.secret_access_key;
       await api.put(`/v1/aws-accounts/${showForm.row.id}`, body);
@@ -353,6 +376,9 @@ export default function AwsAccounts() {
                   state_bucket_region: showForm.row.state_bucket_region,
                   default_region: showForm.row.default_region,
                   aws_profile_name: showForm.row.aws_profile_name ?? "",
+                  // Prefill with the painted colour, not the stored one, so the
+                  // picker shows what the user actually sees on the Runs page.
+                  color: showForm.row.color_effective ?? showForm.row.color ?? "",
                   access_key_id: "",
                   secret_access_key: "",
                 }
@@ -393,7 +419,16 @@ export default function AwsAccounts() {
           {accounts.map((acc) => {
             const tr = testResult[acc.id];
             return (
-              <Card key={acc.id}>
+              <Card key={acc.id} className="relative overflow-hidden">
+                {/* Same rail as a Runs row — Settings previews the cue rather
+                    than just configuring it. */}
+                <span
+                  aria-hidden
+                  className={
+                    "absolute inset-y-0 left-0 w-[3px] " +
+                    ACCOUNT_COLOR_CLASSES[asAccountColor(acc.color_effective ?? acc.color)].solid
+                  }
+                />
                 <CardHeader>
                   <div className="flex min-w-0 items-center gap-3">
                     <span className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-orange-100 text-sm font-semibold text-orange-700 dark:bg-orange-900/40 dark:text-orange-300">

--- a/services/ui/src/pages/AzureSubscriptions.tsx
+++ b/services/ui/src/pages/AzureSubscriptions.tsx
@@ -14,6 +14,8 @@ import {
   Skeleton,
   Spinner,
 } from "../components/ui";
+import { AccountColorPicker } from "../components/AccountTag";
+import { ACCOUNT_COLOR_CLASSES, asAccountColor } from "../components/accountColors";
 
 type AzureSubscription = {
   id: string;
@@ -26,6 +28,9 @@ type AzureSubscription = {
   default_location: string;
   state_storage_account?: string | null;
   state_container?: string | null;
+  // Stored choice (null = auto) vs. what to paint. See accountColors.ts.
+  color?: string | null;
+  color_effective?: string;
   client_secret_masked: string;
 };
 
@@ -39,6 +44,7 @@ type FormState = {
   default_location: string;
   state_storage_account: string;
   state_container: string;
+  color: string;
 };
 
 const EMPTY: FormState = {
@@ -51,6 +57,7 @@ const EMPTY: FormState = {
   default_location: "eastus",
   state_storage_account: "",
   state_container: "",
+  color: "",
 };
 
 function SubForm({
@@ -135,6 +142,14 @@ function SubForm({
             <Label>Description</Label>
             <Input value={f.description} onChange={(e) => update("description", e.target.value)} />
           </div>
+          <div className="md:col-span-2">
+            <Label>Color</Label>
+            <AccountColorPicker value={f.color} onChange={(c) => update("color", c)} />
+            <p className="mt-1 text-xs text-slate-500">
+              Tags this account across the Runs page and Slack alerts. Leave
+              untouched on create to get the first color unused in this business unit.
+            </p>
+          </div>
           <div className="md:col-span-2 mt-1 border-t border-slate-200 pt-3 dark:border-slate-700">
             <p className="text-xs font-medium text-slate-600 dark:text-slate-300">
               Azure Blob state backend (optional)
@@ -213,6 +228,8 @@ export default function AzureSubscriptions() {
         const body: any = { ...f };
         if (!body.state_storage_account) delete body.state_storage_account;
         if (!body.state_container) delete body.state_container;
+        // Absent (not "") lets the API claim the first free colour.
+        if (!body.color) delete body.color;
         await api.post("/v1/azure-subscriptions", body);
       } else if (showForm?.mode === "edit" && showForm.row) {
         // Skip empty client_secret on edit so we keep the existing one.
@@ -277,6 +294,8 @@ export default function AzureSubscriptions() {
           default_location: showForm.row.default_location,
           state_storage_account: showForm.row.state_storage_account ?? "",
           state_container: showForm.row.state_container ?? "",
+          // Prefill with the painted colour so the picker matches Runs.
+          color: showForm.row.color_effective ?? showForm.row.color ?? "",
         }
       : EMPTY;
 
@@ -325,7 +344,15 @@ export default function AzureSubscriptions() {
           {rows.map((row) => {
             const t = testResult[row.id];
             return (
-              <Card key={row.id}>
+              <Card key={row.id} className="relative overflow-hidden">
+                {/* Same rail as a Runs row — see AwsAccounts. */}
+                <span
+                  aria-hidden
+                  className={
+                    "absolute inset-y-0 left-0 w-[3px] " +
+                    ACCOUNT_COLOR_CLASSES[asAccountColor(row.color_effective ?? row.color)].solid
+                  }
+                />
                 <CardBody>
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="min-w-0">

--- a/services/ui/src/pages/Clusters.tsx
+++ b/services/ui/src/pages/Clusters.tsx
@@ -15,6 +15,8 @@ import {
   Skeleton,
   Spinner,
 } from "../components/ui";
+import { AccountColorPicker } from "../components/AccountTag";
+import { ACCOUNT_COLOR_CLASSES, asAccountColor } from "../components/accountColors";
 
 type Cluster = {
   id: string;
@@ -24,6 +26,9 @@ type Cluster = {
   server_url?: string | null;
   default_namespace?: string | null;
   aws_account_id?: string | null;
+  // Stored choice (null = auto) vs. what to paint. See accountColors.ts.
+  color?: string | null;
+  color_effective?: string;
   kubeconfig_tail: string;
   created_at?: string | null;
 };
@@ -34,6 +39,7 @@ type FormState = {
   server_url: string;
   default_namespace: string;
   aws_account_id: string;
+  color: string;
   kubeconfig: string;
 };
 
@@ -43,6 +49,7 @@ const EMPTY: FormState = {
   server_url: "",
   default_namespace: "default",
   aws_account_id: "",
+  color: "",
   kubeconfig: "",
 };
 
@@ -104,6 +111,15 @@ function ClusterForm({
                 onChange={(e) => update("description", e.target.value)}
                 placeholder="Production EKS cluster (eu-west-1)"
               />
+            </div>
+            <div className="sm:col-span-2">
+              <Label>Color</Label>
+              <AccountColorPicker value={f.color} onChange={(c) => update("color", c)} />
+              <p className="mt-1 text-xs text-slate-500">
+                Tags helm runs against this cluster across the Runs page and
+                Slack alerts. Leave untouched on create to get the first color
+                unused in this business unit.
+              </p>
             </div>
             <div className="sm:col-span-2">
               <Label>Server URL (optional)</Label>
@@ -221,6 +237,8 @@ export default function Clusters() {
         name: f.name,
         description: f.description || undefined,
         server_url: f.server_url || undefined,
+        // undefined (not null) so the API auto-assigns rather than storing NULL.
+        color: f.color || undefined,
         default_namespace: f.default_namespace || undefined,
         aws_account_id: f.aws_account_id.trim() || undefined,
         kubeconfig: f.kubeconfig,
@@ -246,6 +264,7 @@ export default function Clusters() {
         default_namespace: f.default_namespace || null,
         aws_account_id: f.aws_account_id.trim() || null,
       };
+      if (f.color) body.color = f.color;
       // Only send kubeconfig when the operator entered a new one; blank keeps
       // the existing encrypted value untouched.
       if (f.kubeconfig) body.kubeconfig = f.kubeconfig;
@@ -307,6 +326,8 @@ export default function Clusters() {
                   server_url: showForm.row.server_url ?? "",
                   default_namespace: showForm.row.default_namespace ?? "",
                   aws_account_id: showForm.row.aws_account_id ?? "",
+                  // Prefill with the painted colour so the picker matches Runs.
+                  color: showForm.row.color_effective ?? showForm.row.color ?? "",
                   kubeconfig: "",
                 }
               : EMPTY
@@ -346,7 +367,15 @@ export default function Clusters() {
           {clusters.map((c) => {
             const tr = testResult[c.id];
             return (
-              <Card key={c.id}>
+              <Card key={c.id} className="relative overflow-hidden">
+                {/* Same rail as a Runs row — see AwsAccounts. */}
+                <span
+                  aria-hidden
+                  className={
+                    "absolute inset-y-0 left-0 w-[3px] " +
+                    ACCOUNT_COLOR_CLASSES[asAccountColor(c.color_effective ?? c.color)].solid
+                  }
+                />
                 <CardHeader>
                   <div className="flex min-w-0 items-center gap-3">
                     <span className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-blue-100 text-sm font-semibold text-blue-700 dark:bg-blue-900/40 dark:text-blue-300">

--- a/services/ui/src/pages/GcpProjects.tsx
+++ b/services/ui/src/pages/GcpProjects.tsx
@@ -14,6 +14,8 @@ import {
   Skeleton,
   Spinner,
 } from "../components/ui";
+import { AccountColorPicker } from "../components/AccountTag";
+import { ACCOUNT_COLOR_CLASSES, asAccountColor } from "../components/accountColors";
 
 type GcpProject = {
   id: string;
@@ -25,6 +27,9 @@ type GcpProject = {
   default_region: string;
   state_bucket?: string | null;
   state_prefix?: string | null;
+  // Stored choice (null = auto) vs. what to paint. See accountColors.ts.
+  color?: string | null;
+  color_effective?: string;
   service_account_masked: string;
 };
 
@@ -35,6 +40,7 @@ type FormState = {
   default_region: string;
   state_bucket: string;
   state_prefix: string;
+  color: string;
   service_account_json: string;
 };
 
@@ -45,6 +51,7 @@ const EMPTY: FormState = {
   default_region: "us-central1",
   state_bucket: "",
   state_prefix: "",
+  color: "",
   service_account_json: "",
 };
 
@@ -122,6 +129,14 @@ function ProjForm({
             <Label>Description</Label>
             <Input value={f.description} onChange={(e) => update("description", e.target.value)} />
           </div>
+          <div className="md:col-span-2">
+            <Label>Color</Label>
+            <AccountColorPicker value={f.color} onChange={(c) => update("color", c)} />
+            <p className="mt-1 text-xs text-slate-500">
+              Tags this account across the Runs page and Slack alerts. Leave
+              untouched on create to get the first color unused in this business unit.
+            </p>
+          </div>
           <div className="md:col-span-2 mt-1 border-t border-slate-200 pt-3 dark:border-slate-700">
             <p className="text-xs font-medium text-slate-600 dark:text-slate-300">
               GCS state backend (optional)
@@ -193,6 +208,8 @@ export default function GcpProjects() {
       // Empty optional fields → null (avoid storing "").
       body.state_bucket = body.state_bucket || null;
       body.state_prefix = body.state_prefix || null;
+      // Absent (not "") lets the API claim the first free colour.
+      if (!body.color) delete body.color;
       if (showForm?.mode === "create") {
         await api.post("/v1/gcp-projects", body);
       } else if (showForm?.mode === "edit" && showForm.row) {
@@ -258,6 +275,8 @@ export default function GcpProjects() {
           default_region: showForm.row.default_region,
           state_bucket: showForm.row.state_bucket ?? "",
           state_prefix: showForm.row.state_prefix ?? "",
+          // Prefill with the painted colour so the picker matches Runs.
+          color: showForm.row.color_effective ?? showForm.row.color ?? "",
           service_account_json: "",
         }
       : EMPTY;
@@ -306,7 +325,15 @@ export default function GcpProjects() {
           {rows.map((row) => {
             const t = testResult[row.id];
             return (
-              <Card key={row.id}>
+              <Card key={row.id} className="relative overflow-hidden">
+                {/* Same rail as a Runs row — see AwsAccounts. */}
+                <span
+                  aria-hidden
+                  className={
+                    "absolute inset-y-0 left-0 w-[3px] " +
+                    ACCOUNT_COLOR_CLASSES[asAccountColor(row.color_effective ?? row.color)].solid
+                  }
+                />
                 <CardBody>
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="min-w-0">

--- a/services/ui/src/pages/RunDetail.tsx
+++ b/services/ui/src/pages/RunDetail.tsx
@@ -17,6 +17,8 @@ import RunSteps from "../components/RunSteps";
 import RunLogsModal from "../components/RunLogsModal";
 import PolicyResults, { PolicyStatusBadge } from "../components/PolicyResults";
 import { useCurrentUser, hasMinRole } from "../hooks/useAuth";
+import { AccountTag } from "../components/AccountTag";
+import { useAccountColors } from "../hooks/useAccountColors";
 
 type Run = {
   id: string;
@@ -43,6 +45,10 @@ type Workspace = {
   repo_ref?: string;
   // "terraform" (default) or "helm".
   kind?: string;
+  // Consumed by useAccountColors to attribute the run to a cloud account.
+  azure_subscription_id?: string | null;
+  gcp_project_id?: string | null;
+  cluster_id?: string | null;
 };
 
 type Tab = "timeline" | "plan" | "policies";
@@ -73,6 +79,7 @@ export default function RunDetail() {
   const user = useCurrentUser();
   const [run, setRun] = useState<Run | null>(null);
   const [workspace, setWorkspace] = useState<Workspace | null>(null);
+  const { badgeFor } = useAccountColors();
   const [planOutput, setPlanOutput] = useState<string | null>(null);
   const [tab, setTab] = useState<Tab>("timeline");
   const [busy, setBusy] = useState<string | null>(null);
@@ -229,6 +236,7 @@ export default function RunDetail() {
   // `planned`; they go straight to `awaiting_approval`.)
   const cancellable = new Set(["pending", "running", "planning", "awaiting_approval"]);
   const isAwaitingApproval = run.status === "awaiting_approval";
+  const account = badgeFor(workspace ?? undefined);
   const tabs: Tab[] = ["timeline", "plan", "policies"];
 
   return (
@@ -239,7 +247,19 @@ export default function RunDetail() {
           workspace ? (
             <span>
               <Link to="/" className="hover:underline">{workspace.name}</Link>{" "}
-              · <span className="font-mono">{workspace.aws_account_id}</span>{" "}
+              ·{" "}
+              {/* Account name + colour dot, matching the Runs row. Falls back
+                  to the raw id when the account isn't registered. */}
+              {account ? (
+                <AccountTag
+                  color={account.color}
+                  name={account.name}
+                  id={account.id}
+                  className="align-middle font-medium"
+                />
+              ) : (
+                <span className="font-mono">{workspace.aws_account_id}</span>
+              )}{" "}
               · <span className="font-mono">{workspace.region}</span>
             </span>
           ) : "Workspace deleted."

--- a/services/ui/src/pages/Runs.tsx
+++ b/services/ui/src/pages/Runs.tsx
@@ -17,6 +17,8 @@ import {
 import { useCurrentUser, hasMinRole } from "../hooks/useAuth";
 import RunSteps from "../components/RunSteps";
 import RunLogsModal from "../components/RunLogsModal";
+import { AccountRail, AccountTag } from "../components/AccountTag";
+import { useAccountColors } from "../hooks/useAccountColors";
 
 type Run = {
   id: string;
@@ -40,6 +42,11 @@ type Workspace = {
   region: string;
   aws_account_id: string;
   tf_working_dir?: string;
+  // Consumed by useAccountColors to attribute the run to a cloud account.
+  kind?: string;
+  azure_subscription_id?: string | null;
+  gcp_project_id?: string | null;
+  cluster_id?: string | null;
 };
 
 type UserLite = {
@@ -111,6 +118,7 @@ export default function Runs() {
   const [logsRunId, setLogsRunId] = useState<string | null>(null);
   const user = useCurrentUser();
   const nav = useNavigate();
+  const { badgeFor } = useAccountColors();
 
   async function load() {
     try {
@@ -246,6 +254,7 @@ export default function Runs() {
           r.status,
           ws?.name ?? "",
           ws?.aws_account_id ?? "",
+          badgeFor(ws)?.name ?? "",
           ws?.region ?? "",
           ws?.environment ?? "",
           u?.email ?? "",
@@ -256,7 +265,7 @@ export default function Runs() {
       })
       .slice()
       .sort((a, b) => (b.created_at ?? "").localeCompare(a.created_at ?? ""));
-  }, [runs, workspaces, users, filter, statusFilter]);
+  }, [runs, workspaces, users, filter, statusFilter, badgeFor]);
 
   const statusCounts = useMemo(() => {
     const c: Record<string, number> = {};
@@ -401,11 +410,20 @@ export default function Runs() {
                 <ul className="divide-y divide-slate-200 dark:divide-slate-800/80">
                   {g.runs.map((run) => {
                     const ws = workspaces[run.workspace_id];
+                    const account = badgeFor(ws);
                     const u = run.triggered_by ? users[run.triggered_by] : undefined;
                     const triggerLabel = u?.email ?? (run.triggered_by?.startsWith("webhook:") ? run.triggered_by : run.triggered_by?.slice(0, 8) ?? "—");
                     const isOpen = openRunId === run.id;
                     return (
-                      <li key={run.id} className={cx("transition-colors", isOpen && "bg-slate-50 dark:bg-slate-900/40") }>
+                      <li
+                        key={run.id}
+                        className={cx("relative transition-colors", isOpen && "bg-slate-50 dark:bg-slate-900/40")}
+                      >
+                        {/* Colour rail: which cloud account this run touched.
+                            Absent (not gray) when the workspace has no
+                            attributable account, so "no account" and "gray
+                            account" stay distinguishable. */}
+                        {account && <AccountRail color={account.color} />}
                         <div className="flex flex-wrap items-start gap-3 px-5 py-4">
                           {/* left column: workspace context */}
                           <div className="min-w-0 flex-1">
@@ -459,12 +477,27 @@ export default function Runs() {
                               </span>
                               <RunStatusBadge status={run.status} />
                             </div>
-                            <p className="mt-1 truncate font-mono text-[11px] text-slate-500">
+                            <p className="mt-1 flex min-w-0 items-center gap-1 truncate font-mono text-[11px] text-slate-500">
                               {ws ? (
                                 <>
-                                  {ws.aws_account_id} · {ws.region}
+                                  {/* Account name beats the 12-digit id for
+                                      recognition; the id stays in the tooltip
+                                      (and is still searchable above). Falls
+                                      back to the raw id for an unregistered or
+                                      deleted account. */}
+                                  {account ? (
+                                    <AccountTag
+                                      color={account.color}
+                                      name={account.name}
+                                      id={account.id}
+                                      className="max-w-[14rem] font-sans font-medium text-slate-600 dark:text-slate-300"
+                                    />
+                                  ) : (
+                                    <span>{ws.aws_account_id}</span>
+                                  )}
+                                  <span>· {ws.region}</span>
                                   {ws.tf_working_dir && ws.tf_working_dir !== "." && (
-                                    <> · {ws.tf_working_dir}</>
+                                    <span className="truncate">· {ws.tf_working_dir}</span>
                                   )}
                                 </>
                               ) : (


### PR DESCRIPTION
## Why

Runs were only attributable by their bare 12-digit AWS account id. Nobody reads
`444444444444` at a glance, so telling a prod run from a dev run meant squinting
at digits:

```
platform › gitops-prod   [prod] [apply] [applied]
444444444444 · us-east-1 · account-444444444444/us-east-1/platform/gitops
^^^^^^^^^^^^ which account is this again?
```

Every cloud account (AWS / Azure / GCP / K8s cluster) now carries a colour that
shows up wherever a run is listed or announced.

## The palette decision

**Eight fixed tokens** — `red orange yellow green blue purple brown gray` — not
a free-form hex picker:

- The UI is theme-aware. A user-picked hex is illegible in one of the two
  themes; a token maps to a curated light/dark Tailwind pair.
- Keeps the project's no-hard-coded-colours rule intact.
- Slack ships only ~8 coloured-circle emoji, so 8 keeps UI ↔ Slack strictly 1:1.

**No teal** — Tailwind's `sky` is aliased to the brand teal in this repo, so a
teal account would read as chrome rather than as data.

Defined twice and kept in sync by hand, each file commented with its role:

| | File |
|---|---|
| Backend | `services/api/app/services/account_colors.py` — Slack hex + emoji, validation, assignment |
| Frontend | `services/ui/src/components/accountColors.ts` — light/dark Tailwind pairs |

## Assignment: claimed at creation, never shifts

A colour is claimed when the account is created — the first one unused in the
Business Unit, **spanning all four provider tables** (a colour reused across
providers is as confusing as one reused within a provider), and it never changes
afterwards.

The first cut derived the colour from a hash of the account id instead. Tested
against three accounts and two collided — with 8 buckets that's a ~30% collision
at three accounts, which defeats the whole point. The hash survives only as a
fallback for rows inserted outside the API (seed scripts, direct SQL, a restored
dump).

`041_account_color` adds a nullable `color VARCHAR(16)` to all four
cloud-account tables and **backfills every existing row** the same way, so no
existing deployment has to visit Settings to get a usable palette. The palette
is inlined in the migration as a frozen snapshot — a migration must keep
producing the same result even after the application palette grows.

The API returns both `color` (stored; null = auto) and `color_effective` (always
populated — what to paint), so the derived-default logic lives in exactly one
place: the server.

## UI

A 3px rail down each Runs row, and the 12-digit id replaced by a colour dot plus
the account **name** (the id moves to the tooltip and stays searchable in the
filter box):

```
┃ platform › gitops-prod        [prod] [apply] [applied]
┃ ● Prod-Account · us-east-1 · platform/gitops
┗━ red rail

┃ secrets › vault-oidc [dev] [plan] [planned]
┃ ● Dev-Account · eu-west-1 · secrets/vault-oidc
┗━ orange rail
```

- **Colour is never the only channel** — the name always sits beside the dot, so
  rows stay readable in grayscale and for colourblind users.
- The rail is **absent, not gray**, when a workspace has no attributable
  account, so "no account" and "gray account" stay distinguishable.
- `RunDetail` shows the same tag in its subtitle.
- All four provider pages in Settings get an 8-swatch picker and preview the
  colour as a rail on the account card.

## Slack

`post_message` gained `color=`, which moves the blocks inside a single
attachment — the only way to get Slack's left stripe, since Block Kit has no
equivalent. The four bot-token senders **and** both legacy `slack.webhook_url`
senders resolve the account, add an **Account** field, and prefix the emoji onto
the fallback `text` so mobile pushes — which render neither attachments nor
blocks — still carry the cue. The matching emails name the account too, so the
two channels can't disagree.

Resolution order is identical in the UI and in Slack (helm → cluster, else
Azure → GCP → AWS), so a run is the same colour in both.

## Two incidental fixes

- The legacy webhook payloads sent `blocks` with **no top-level `text`**, which
  leaves Slack mobile pushes blank. Now always set.
- `useAccountColors` refetches on a Business Unit switch. The switcher fires an
  event but does **not** reload the page, so a fetch-once hook would keep
  serving the previous BU's accounts and every row in the new BU would silently
  fall back to a bare account id. Verified in-browser: 1 fetch on mount → 2
  after a switch.

## Note on `Approvals.tsx`

While building this I added the rail to `Approvals.tsx`, then found the page
isn't routed and isn't imported — `/approvals` redirects to
`/runs?status=awaiting_approval`, so Vite drops it from the bundle entirely.
Those edits were reverted rather than ship unreachable code. The approvals
workflow lives entirely in `Runs.tsx` behind that status filter.

## Testing

| | Result |
|---|---|
| API suite (`pytest`) | see CI |
| UI (`tsc` / `vite build` / `vitest`) | clean · clean · **67 passed** |

- `test_account_colors.py` (11): palette/Slack-table agreement, validation
  (including rejecting `teal`), hash stability across processes, `pick_next`
  distinctness and overflow spreading, plus the API contract — distinct colours
  on create, explicit round-trip, clearing back to auto, 422 on garbage, and
  that an unrelated update doesn't wipe the colour.
- `useAccountColors.test.ts` (7): that AWS keys by the 12-digit id and **not**
  the row PK, helm attributes to the cluster, the `global` sentinel isn't an
  account, one provider endpoint 403-ing doesn't cost the others their colours,
  and an unknown colour degrades to gray instead of throwing on an undefined
  class lookup.
- Slack: the attachment/stripe payload shape is pinned for both the bot-token
  and the legacy webhook paths, including the unstriped back-compat path.
- Confirmed all 8 swatches and their dark variants reach the emitted CSS —
  Tailwind silently drops classes it can't see, so the class strings are written
  out literally rather than composed.

**Not verified:** Slack output against a live channel, and the email bodies
against a real SMTP server. Both are covered at the payload/body level by unit
tests.
