### PR TITLE
feat: API-key rotation with an overlap window, and workspace tags

### DIFF
--- a/.claude/skills/tdt/SKILL.md
+++ b/.claude/skills/tdt/SKILL.md
@@ -64,6 +64,9 @@ tdt run destroy <workspace> --yes --auto-approve --max-destroy 1
 ```bash
 tdt context -o json                  # one-shot BU snapshot: workspaces, recent runs, drift
 tdt ws list                          # add -o json for ids
+tdt ws list -t team=payments         # filter by tag; repeatable and AND-ed
+tdt ws tags                          # every tag key in the BU, with counts
+tdt ws tag <ws> -s team=payments     # set/unset tags; --set merges, never clobbers
 tdt run list -w <workspace> --status failed -n 5
 tdt run get <run-id>
 tdt run graph <run-id>               # the +/~/-/± diff and changed addresses

--- a/services/api/alembic/versions/042_api_key_rotation_overlap.py
+++ b/services/api/alembic/versions/042_api_key_rotation_overlap.py
@@ -1,0 +1,50 @@
+"""api_key rotation with an overlap window
+
+Adds the two columns a rotation needs to leave an audit trail:
+
+  rotated_at        — when this key was superseded. Distinguishes an expiry set
+                      by a rotation from one an admin chose, so the UI can say
+                      "retiring in 6h" rather than just "expires".
+  superseded_by_id  — the key that replaced it. ON DELETE SET NULL, because
+                      deleting the successor must not erase the predecessor's
+                      history.
+
+No data migration: existing keys have never been rotated, so NULL is correct
+for both. Nothing about the auth path changes — the overlap is enforced by the
+existing `expires_at` check in api_key_service.is_active().
+
+Revision ID: 042_api_key_rotation_overlap
+Revises: 041_account_color
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "042_api_key_rotation_overlap"
+down_revision = "041_account_color"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "api_keys",
+        sa.Column("rotated_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "api_keys",
+        sa.Column("superseded_by_id", sa.String(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_api_keys_superseded_by_id",
+        "api_keys",
+        "api_keys",
+        ["superseded_by_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_api_keys_superseded_by_id", "api_keys", type_="foreignkey")
+    op.drop_column("api_keys", "superseded_by_id")
+    op.drop_column("api_keys", "rotated_at")

--- a/services/api/alembic/versions/043_workspace_tags.py
+++ b/services/api/alembic/versions/043_workspace_tags.py
@@ -1,0 +1,32 @@
+"""workspace key/value tags
+
+Adds `workspaces.tags` as a JSON object, e.g. {"team": "payments"}.
+
+A JSON column rather than a `workspace_tags` join table: at this fleet size
+(low hundreds per BU) a dict scan gives what an index would, and it keeps tags
+atomic with the row they describe — no partial write, no orphan cleanup when a
+workspace is deleted, which is a class of bug this schema already had elsewhere.
+If a deployment outgrows holding a BU's workspaces in memory, the upgrade path
+is a real table behind the same API shape.
+
+Nullable with no default: an untagged workspace is NULL, which reads the same
+as {} everywhere through `workspace_tags.matches()`.
+
+Revision ID: 043_workspace_tags
+Revises: 042_api_key_rotation_overlap
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "043_workspace_tags"
+down_revision = "042_api_key_rotation_overlap"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("workspaces", sa.Column("tags", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("workspaces", "tags")

--- a/services/api/app/models/api_key.py
+++ b/services/api/app/models/api_key.py
@@ -71,3 +71,21 @@ class APIKey(Base):
     revoked_at: Mapped[DateTime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    # ─── Rotation with overlap ────────────────────────────────────────────
+    # A rotation mints a *successor* row rather than replacing this row's
+    # secret, because an overlap window needs two usable secrets at once and
+    # `token_hash` is unique per row. The old key keeps working until its
+    # `expires_at` (set to now + overlap at rotation time) passes, which
+    # `is_active()` already enforces — no new auth path.
+    #
+    # `rotated_at` is what distinguishes "this expiry was set by a rotation"
+    # from "an admin gave this key an expiry", so the UI can say *retiring*
+    # rather than merely *expiring*.
+    rotated_at: Mapped[DateTime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    # The key that replaced this one. SET NULL rather than CASCADE: deleting a
+    # successor must never delete the audit trail of its predecessor.
+    superseded_by_id: Mapped[str | None] = mapped_column(
+        String, ForeignKey("api_keys.id", ondelete="SET NULL"), nullable=True
+    )

--- a/services/api/app/models/workspace.py
+++ b/services/api/app/models/workspace.py
@@ -1,5 +1,5 @@
 import uuid
-from sqlalchemy import Boolean, ForeignKey, String, Text, DateTime, UniqueConstraint, func
+from sqlalchemy import JSON, Boolean, ForeignKey, String, Text, DateTime, UniqueConstraint, func
 from sqlalchemy.orm import Mapped, mapped_column
 from app.db import Base
 
@@ -95,6 +95,11 @@ class Workspace(Base):
     # For kind="helm": the target K8s cluster (k8s_clusters.id). Null for
     # terraform workspaces (and for helm workspaces not yet wired to a cluster).
     cluster_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    # Free-form key/value tags, e.g. {"team": "payments", "tier": "prod"}.
+    # A JSON object rather than a join table: at this fleet size a dict scan
+    # matches what an index would give, and it keeps tags atomic with the row
+    # they describe. See app/services/workspace_tags.py.
+    tags: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     created_at: Mapped[DateTime] = mapped_column(DateTime(timezone=True), server_default=func.now())
 
     @property

--- a/services/api/app/routers/api_keys.py
+++ b/services/api/app/routers/api_keys.py
@@ -11,7 +11,7 @@ even for `admin`-tier keys (which otherwise satisfy `require_role(admin)`).
 Letting a key mint or revoke keys would be a privilege-escalation hole.
 """
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
@@ -24,7 +24,13 @@ from app.models.api_key import APIKey
 from app.models.audit_log import AuditLog
 from app.models.user import User
 from app.models.workspace import Workspace
-from app.schemas.api_key import APIKeyCreate, APIKeyCreateResponse, APIKeyResponse
+from app.schemas.api_key import (
+    APIKeyCreate,
+    APIKeyCreateResponse,
+    APIKeyResponse,
+    APIKeyRotate,
+    APIKeyRotateResponse,
+)
 from app.services import api_key_service
 from app.services.audit_chain import stamp
 
@@ -206,6 +212,124 @@ async def regenerate_api_key(
 
     base = APIKeyResponse.model_validate(key, from_attributes=True)
     return APIKeyCreateResponse(**base.model_dump(), token=plaintext)
+
+
+@router.post(
+    "/{key_id}/rotate",
+    response_model=APIKeyRotateResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def rotate_api_key(
+    key_id: str,
+    body: APIKeyRotate | None = None,
+    current_user: User = Depends(require_role(Role.admin)),
+    bu: BUScope = Depends(current_bu),
+    db: AsyncSession = Depends(get_db),
+):
+    """Mint a successor key, leaving the old one usable for an overlap window.
+
+    The difference from `/regenerate` is the whole point. `regenerate` swaps a
+    key's secret in place and the old one dies that instant — fine if exactly
+    one consumer holds it, useless when the same key sits in a CI secret store,
+    a laptop keychain and a cron job, because you cannot update all three
+    atomically. Rotation gives you a window in which **both** secrets work, so
+    consumers can be moved over one at a time.
+
+    Two rows are involved, not one, because an overlap needs two usable secrets
+    and `token_hash` is unique per row:
+
+      old key → `expires_at` pulled in to now + overlap_hours, `rotated_at` set,
+                `superseded_by_id` pointed at the new key. Nothing else changes,
+                so it keeps authenticating until the window closes.
+      new key → same name, capability, workspace scope, owner and BU; fresh
+                secret, returned once.
+
+    `overlap_hours=0` cuts over immediately. If the old key already expires
+    sooner than the requested window, its earlier expiry wins — a rotation must
+    never *extend* a credential's life.
+    """
+    bu_id = _require_bu(bu)
+    opts = body or APIKeyRotate()
+
+    key = await db.get(APIKey, key_id)
+    if key is None or key.business_unit_id != bu_id:
+        raise HTTPException(status_code=404, detail="API key not found")
+    if key.revoked_at is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Cannot rotate a revoked key — create a new one instead.",
+        )
+    if not api_key_service.is_active(key):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Cannot rotate an expired key — create a new one instead.",
+        )
+    if key.superseded_by_id is not None:
+        # Chaining rotations would leave several live secrets behind one name
+        # and make "which one do I retire?" ambiguous.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "This key has already been rotated; rotate its successor "
+                f"({key.superseded_by_id}) instead."
+            ),
+        )
+
+    now = datetime.now(timezone.utc)
+    plaintext, prefix, token_hash = api_key_service.generate_token()
+    successor = APIKey(
+        name=key.name,
+        token_prefix=prefix,
+        token_hash=token_hash,
+        user_id=key.user_id,
+        business_unit_id=key.business_unit_id,
+        capability=key.capability,
+        workspace_ids=key.workspace_ids,
+        expires_at=key.expires_at,
+        created_by=current_user.id,
+    )
+    db.add(successor)
+    await db.flush()
+
+    # Never extend the credential's life: if the old key already dies before the
+    # window would close, keep the earlier deadline.
+    window_end = now + timedelta(hours=opts.overlap_hours)
+    old_expiry = key.expires_at
+    if old_expiry is not None and old_expiry.tzinfo is None:
+        old_expiry = old_expiry.replace(tzinfo=timezone.utc)
+    key.expires_at = window_end if old_expiry is None else min(old_expiry, window_end)
+    key.rotated_at = now
+    key.superseded_by_id = successor.id
+
+    audit = AuditLog(
+        user_id=current_user.id,
+        action="api_key.rotate",
+        resource_type="api_key",
+        resource_id=key.id,
+        details={
+            "name": key.name,
+            "capability": key.capability,
+            "business_unit_id": bu_id,
+            "old_token_prefix": key.token_prefix,
+            "new_token_prefix": prefix,
+            "successor_id": successor.id,
+            "overlap_hours": opts.overlap_hours,
+            "predecessor_expires_at": key.expires_at.isoformat(),
+        },
+    )
+    db.add(audit)
+    await stamp(db, audit)
+    await db.commit()
+    await db.refresh(successor)
+    await db.refresh(key)
+
+    base = APIKeyResponse.model_validate(successor, from_attributes=True)
+    return APIKeyRotateResponse(
+        **base.model_dump(),
+        token=plaintext,
+        predecessor_id=key.id,
+        predecessor_expires_at=key.expires_at,
+    )
 
 
 @router.delete("/{key_id}", status_code=status.HTTP_200_OK)

--- a/services/api/app/routers/workspaces.py
+++ b/services/api/app/routers/workspaces.py
@@ -5,7 +5,7 @@ import re
 import uuid
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -90,6 +90,7 @@ def _gcp_project_id_from_path(path: str) -> str | None:
         if m:
             return m.group(1)
     return None
+from app.models.audit_log import AuditLog
 from app.schemas.workspace import (
     BulkImportRequest,
     BulkImportResult,
@@ -97,12 +98,18 @@ from app.schemas.workspace import (
     DiscoveryRequest,
     DiscoveryResultOut,
     StackCandidateOut,
+    TagKey,
+    TagValue,
     WorkspaceCreate,
     WorkspaceResponse,
+    WorkspaceTagEdit,
+    WorkspaceTagEditResult,
     WorkspaceUpdate,
 )
 from app.services import repo_discovery
 from app.services import api_key_service
+from app.services import workspace_tags
+from app.services.audit_chain import stamp
 
 router = APIRouter(prefix="/api/v1/workspaces", tags=["workspaces"])
 
@@ -146,6 +153,14 @@ async def _validate_state_backend_linkage(
 
 @router.get("", response_model=list[WorkspaceResponse])
 async def list_workspaces(
+    tag: list[str] | None = Query(
+        None,
+        description=(
+            "Filter by tag, repeatable and AND-ed: `?tag=team=payments&tag=tier=prod`. "
+            "A bare key (`?tag=owner`) matches any workspace carrying it, whatever "
+            "the value."
+        ),
+    ),
     current_user: User = Depends(require_role(Role.viewer)),
     bu: BUScope = Depends(current_bu),
     db: AsyncSession = Depends(get_db),
@@ -154,12 +169,121 @@ async def list_workspaces(
 
     Superadmin with no `X-Business-Unit` header (or `all`) sees every workspace
     across all BUs.
+
+    Tag matching happens in Python, not SQL: `tags` is a JSON column and the
+    predicate would not be portable across SQLite and Postgres. The BU scope is
+    still applied in the query, so this only ever walks one BU's rows.
     """
     stmt = select(Workspace)
     if bu.bu_id is not None:
         stmt = stmt.where(Workspace.business_unit_id == bu.bu_id)
-    result = await db.execute(stmt)
-    return result.scalars().all()
+    rows = (await db.execute(stmt)).scalars().all()
+
+    if tag:
+        try:
+            filters = [workspace_tags.parse_filter(t) for t in tag]
+        except workspace_tags.TagError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        rows = [w for w in rows if workspace_tags.matches(w.tags, filters)]
+    return rows
+
+
+@router.get("/tags", response_model=list[TagKey])
+async def list_workspace_tags(
+    current_user: User = Depends(require_role(Role.viewer)),
+    bu: BUScope = Depends(current_bu),
+    db: AsyncSession = Depends(get_db),
+):
+    """Every tag key in this BU with its values and usage counts.
+
+    Feeds filter autocomplete, and answers "what tags do we actually use?" —
+    which is how you notice `team`/`owner` drift apart before it is entrenched.
+
+    Declared before `/{workspace_id}` so the literal path wins the route match;
+    otherwise "tags" would be read as a workspace id.
+    """
+    stmt = select(Workspace)
+    if bu.bu_id is not None:
+        stmt = stmt.where(Workspace.business_unit_id == bu.bu_id)
+    rows = (await db.execute(stmt)).scalars().all()
+
+    counts: dict[str, dict[str, int]] = {}
+    for ws in rows:
+        for key, value in (ws.tags or {}).items():
+            counts.setdefault(key, {}).setdefault(value, 0)
+            counts[key][value] += 1
+
+    return [
+        TagKey(
+            key=key,
+            count=sum(values.values()),
+            values=[
+                TagValue(value=v, count=c)
+                for v, c in sorted(values.items(), key=lambda kv: (-kv[1], kv[0]))
+            ],
+        )
+        for key, values in sorted(counts.items())
+    ]
+
+
+@router.post("/tags", response_model=WorkspaceTagEditResult)
+async def bulk_edit_workspace_tags(
+    body: WorkspaceTagEdit,
+    current_user: User = Depends(require_role(Role.operator)),
+    bu: BUScope = Depends(current_bu),
+    db: AsyncSession = Depends(get_db),
+):
+    """Set and/or unset tags across many workspaces in one call.
+
+    `set` merges per key rather than replacing the map, so retagging twenty
+    workspaces' `team` cannot wipe the `owner` tag one of them happens to carry.
+
+    All-or-nothing: an id outside the current BU fails the whole request rather
+    than silently tagging a subset, because a partial bulk edit is worse than a
+    rejected one — you cannot tell which half applied.
+    """
+    if not body.set and not body.unset:
+        raise HTTPException(status_code=400, detail="nothing to set or unset")
+
+    stmt = select(Workspace).where(Workspace.id.in_(body.workspace_ids))
+    if bu.bu_id is not None:
+        stmt = stmt.where(Workspace.business_unit_id == bu.bu_id)
+    rows = (await db.execute(stmt)).scalars().all()
+
+    missing = set(body.workspace_ids) - {w.id for w in rows}
+    if missing:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Workspaces not in this BU: {', '.join(sorted(missing))}",
+        )
+
+    try:
+        for ws in rows:
+            merged = workspace_tags.apply_edit(ws.tags, body.set, body.unset)
+            # Reassign rather than mutate: SQLAlchemy does not track in-place
+            # edits to a JSON dict, so a mutation would silently not persist.
+            ws.tags = merged or None
+    except workspace_tags.TagError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # One row per workspace rather than one for the batch: `resource_id` is NOT
+    # NULL, and per-resource entries are what make "what happened to workspace
+    # X?" answerable later. `stamp` chains them, so they must be added in order.
+    for ws in rows:
+        audit = AuditLog(
+            user_id=current_user.id,
+            action="workspace.tags_bulk_edit",
+            resource_type="workspace",
+            resource_id=ws.id,
+            workspace_id=ws.id,
+            details={"set": body.set, "unset": body.unset, "tags_after": ws.tags or {}},
+        )
+        db.add(audit)
+        await stamp(db, audit)
+    await db.commit()
+    for ws in rows:
+        await db.refresh(ws)
+    return WorkspaceTagEditResult(updated=len(rows), workspaces=rows)
 
 
 @router.get("/{workspace_id}", response_model=WorkspaceResponse)
@@ -270,6 +394,11 @@ async def create_workspace(
         db, state_backend, azure_sub_pk, gcp_project_pk
     )
 
+    try:
+        create_tags = workspace_tags.validate(body.tags or {})
+    except workspace_tags.TagError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
     ws = Workspace(
         id=str(uuid.uuid4()),
         business_unit_id=bu.bu_id,
@@ -286,6 +415,7 @@ async def create_workspace(
         azure_subscription_id=azure_sub_pk,
         gcp_project_id=gcp_project_pk,
         state_backend=state_backend,
+        tags=create_tags or None,
     )
     db.add(ws)
     await _commit_or_conflict(
@@ -426,6 +556,14 @@ async def update_workspace(
             else ws.gcp_project_id
         )
         await _validate_state_backend_linkage(db, effective_backend, eff_azure, eff_gcp)
+
+    if "tags" in update_data:
+        # PUT replaces the whole map. Validate before the blind setattr below,
+        # which would otherwise persist an unvalidated dict straight to JSON.
+        try:
+            update_data["tags"] = workspace_tags.validate(update_data["tags"] or {}) or None
+        except workspace_tags.TagError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     for field, value in update_data.items():
         setattr(ws, field, value)

--- a/services/api/app/schemas/api_key.py
+++ b/services/api/app/schemas/api_key.py
@@ -26,6 +26,22 @@ class APIKeyCreate(BaseModel):
     expires_at: Optional[datetime] = None
 
 
+DEFAULT_OVERLAP_HOURS = 24
+MAX_OVERLAP_HOURS = 24 * 7
+
+
+class APIKeyRotate(BaseModel):
+    """Body for `POST /api-keys/{id}/rotate`."""
+
+    # How long the OLD secret keeps working after the new one is minted. The
+    # point of the whole feature: you cannot atomically swap a credential that
+    # lives in a CI secret store, a laptop keychain and a cron job at once.
+    # 0 means immediate cutover, which is what `regenerate` does in place.
+    overlap_hours: int = Field(
+        default=DEFAULT_OVERLAP_HOURS, ge=0, le=MAX_OVERLAP_HOURS
+    )
+
+
 class APIKeyResponse(BaseModel):
     id: str
     name: str
@@ -39,6 +55,10 @@ class APIKeyResponse(BaseModel):
     last_used_at: Optional[datetime] = None
     expires_at: Optional[datetime] = None
     revoked_at: Optional[datetime] = None
+    # Set when this key was superseded by a rotation; `expires_at` then marks
+    # the end of its overlap window.
+    rotated_at: Optional[datetime] = None
+    superseded_by_id: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -47,3 +67,15 @@ class APIKeyCreateResponse(APIKeyResponse):
     """Returned exactly once on creation — includes the plaintext token."""
 
     token: str
+
+
+class APIKeyRotateResponse(APIKeyCreateResponse):
+    """The successor key, plus what happens to the one it replaced.
+
+    Returned once, like creation. `predecessor_expires_at` is the deadline for
+    swapping the old secret out of wherever it lives; after it passes the old
+    key stops authenticating on its own, with no second call needed.
+    """
+
+    predecessor_id: str
+    predecessor_expires_at: Optional[datetime] = None

--- a/services/api/app/schemas/workspace.py
+++ b/services/api/app/schemas/workspace.py
@@ -96,6 +96,8 @@ class WorkspaceCreate(BaseModel):
     gcp_project_id: Optional[str] = None
     # Where Terraform state is stored: "s3" (default), "azureblob", or "gcs".
     state_backend: str = "s3"
+    # Key/value tags, e.g. {"team": "payments"}. Keys are lowercased.
+    tags: Optional[dict] = None
 
     @field_validator("kind")
     @classmethod
@@ -138,6 +140,9 @@ class WorkspaceUpdate(BaseModel):
     # Change where state is stored: "s3", "azureblob", or "gcs". The router
     # validates the required cloud linkage before applying the change.
     state_backend: Optional[str] = None
+    # Replaces the whole tag map. Use POST /workspaces/tags to edit
+    # individual keys across many workspaces without clobbering others.
+    tags: Optional[dict] = None
 
     @field_validator("state_backend")
     @classmethod
@@ -165,6 +170,11 @@ class WorkspaceResponse(BaseModel):
     kind: str = "terraform"
     # Target k8s cluster FK for helm workspaces, else null.
     cluster_id: Optional[str] = None
+    # Always an object, never null: an untagged workspace stores NULL but
+    # every consumer wants to iterate it without a guard. `default_factory`
+    # alone is not enough — it fires when the field is *absent*, not when the
+    # ORM hands us an explicit None — hence the coercing validator below.
+    tags: dict = Field(default_factory=dict)
     drift_status: str = "unknown"
     path_status: str = "unknown"
     path_status_checked_at: Optional[datetime] = None
@@ -187,6 +197,10 @@ class WorkspaceResponse(BaseModel):
 # Git-tree discovery / bulk import
 # ---------------------------------------------------------------------------
 
+    @field_validator("tags", mode="before")
+    @classmethod
+    def _null_tags_are_empty(cls, v):
+        return {} if v is None else v
 
 class StackCandidateOut(BaseModel):
     path: str
@@ -272,3 +286,34 @@ class BulkImportRequest(BaseModel):
 class BulkImportResult(BaseModel):
     created: List[WorkspaceResponse]
     skipped: List[dict]  # {"path": ..., "reason": ...}
+
+
+# ─── tags ───────────────────────────────────────────────────────────────────
+
+
+class WorkspaceTagEdit(BaseModel):
+    """Bulk tag edit — `POST /workspaces/tags`.
+
+    `set` merges per key rather than replacing the map, so retagging twenty
+    workspaces' `team` cannot wipe the `owner` tag one of them happens to have.
+    """
+
+    workspace_ids: list[str] = Field(min_length=1)
+    set: dict = Field(default_factory=dict)
+    unset: list[str] = Field(default_factory=list)
+
+
+class WorkspaceTagEditResult(BaseModel):
+    updated: int
+    workspaces: list[WorkspaceResponse]
+
+
+class TagValue(BaseModel):
+    value: str
+    count: int
+
+
+class TagKey(BaseModel):
+    key: str
+    count: int
+    values: list[TagValue]

--- a/services/api/app/services/workspace_tags.py
+++ b/services/api/app/services/workspace_tags.py
@@ -1,0 +1,116 @@
+"""Key/value tags on workspaces: validation, normalization, matching.
+
+Stored as a JSON object on `workspaces.tags` rather than a join table. At this
+fleet size (low hundreds of workspaces per BU) a table plus a GIN index buys
+nothing a dict scan doesn't already give, and it keeps tags atomic with the row
+they describe — no partial write, no orphan cleanup on delete. If a deployment
+ever grows to where `list_workspaces` can't hold the BU in memory, the upgrade
+path is a `workspace_tags` table with the same public shape.
+
+Keys are normalized to lowercase because `Team` and `team` being different tags
+is a bug every tagging system learns the hard way. Values keep their case: they
+are frequently display text.
+"""
+from __future__ import annotations
+
+import re
+
+# Deliberately narrow: tags end up in URLs, Slack messages and (later) cloud
+# provider tags, all of which have their own opinions about punctuation.
+_KEY_RE = re.compile(r"[a-z0-9][a-z0-9._-]{0,62}[a-z0-9]|[a-z0-9]")
+_VALUE_RE = re.compile(r"[\w .:/@+=-]{0,255}", re.UNICODE)
+
+MAX_TAGS_PER_WORKSPACE = 32
+KEY_MAX = 64
+VALUE_MAX = 255
+
+
+class TagError(ValueError):
+    """Raised with a message intended for a 400 response."""
+
+
+def normalize_key(key: str) -> str:
+    return (key or "").strip().lower()
+
+
+def validate(tags: dict) -> dict[str, str]:
+    """Validate and normalize a whole tag map. Returns the cleaned copy."""
+    if not isinstance(tags, dict):
+        raise TagError("tags must be an object of key → value")
+    if len(tags) > MAX_TAGS_PER_WORKSPACE:
+        raise TagError(f"at most {MAX_TAGS_PER_WORKSPACE} tags per workspace")
+
+    cleaned: dict[str, str] = {}
+    for raw_key, raw_value in tags.items():
+        key = normalize_key(str(raw_key))
+        if not key:
+            raise TagError("tag keys cannot be blank")
+        if len(key) > KEY_MAX:
+            raise TagError(f"tag key '{key[:16]}…' exceeds {KEY_MAX} characters")
+        if not _KEY_RE.fullmatch(key):
+            raise TagError(
+                f"invalid tag key '{key}': use lowercase letters, digits, "
+                "'.', '_' or '-', starting and ending alphanumeric"
+            )
+        if raw_value is None:
+            value = ""
+        elif isinstance(raw_value, (str, int, float, bool)):
+            value = str(raw_value)
+        else:
+            raise TagError(f"tag '{key}' must have a scalar value")
+        if len(value) > VALUE_MAX:
+            raise TagError(f"tag '{key}' value exceeds {VALUE_MAX} characters")
+        if not _VALUE_RE.fullmatch(value):
+            raise TagError(f"tag '{key}' has an invalid value")
+        # Normalizing the key can collide two distinct inputs ("Team"/"team").
+        if key in cleaned:
+            raise TagError(f"duplicate tag key '{key}' after normalization")
+        cleaned[key] = value
+    return cleaned
+
+
+def parse_filter(expr: str) -> tuple[str, str | None]:
+    """`team=payments` → ('team', 'payments'); `team` → ('team', None).
+
+    A bare key matches any workspace carrying it, whatever the value — useful
+    for "everything that has an owner set".
+    """
+    expr = (expr or "").strip()
+    if not expr:
+        raise TagError("empty tag filter")
+    if "=" not in expr:
+        return normalize_key(expr), None
+    key, _, value = expr.partition("=")
+    key = normalize_key(key)
+    if not key:
+        raise TagError(f"tag filter '{expr}' has no key")
+    return key, value.strip()
+
+
+def matches(tags: dict | None, filters: list[tuple[str, str | None]]) -> bool:
+    """AND across filters — every one must hold."""
+    have = tags or {}
+    for key, value in filters:
+        if key not in have:
+            return False
+        if value is not None and have[key] != value:
+            return False
+    return True
+
+
+def apply_edit(
+    current: dict | None,
+    set_tags: dict | None = None,
+    unset_keys: list[str] | None = None,
+) -> dict[str, str]:
+    """Merge a bulk edit onto one workspace's tags.
+
+    `set` overwrites per key rather than replacing the whole map, so editing
+    twenty workspaces' `team` tag can't wipe the `owner` tag one of them has.
+    """
+    merged = dict(current or {})
+    for key in unset_keys or []:
+        merged.pop(normalize_key(key), None)
+    if set_tags:
+        merged.update(validate(set_tags))
+    return validate(merged)

--- a/services/api/tests/test_api_keys.py
+++ b/services/api/tests/test_api_keys.py
@@ -526,3 +526,242 @@ async def test_admin_key_confined_to_its_bu(auth_client, admin_token, default_bu
         f"/api/v1/workspaces/{other_ws}", json={"name": "pwned"}, headers=hk
     )
     assert upd.status_code == 404, upd.text
+
+
+# ─── rotation with an overlap window ────────────────────────────────────────
+
+
+async def _rotate(client, admin_token, key_id, **body) -> dict:
+    r = await client.post(
+        f"/api/v1/api-keys/{key_id}/rotate", json=body or {}, headers=_h(admin_token)
+    )
+    assert r.status_code == 201, r.text
+    return r.json()
+
+
+def _as_utc(value: str) -> datetime:
+    """Parse a timestamp from the API, tolerating a missing offset.
+
+    SQLite does not persist tzinfo, so under the test DB a `DateTime(timezone=
+    True)` column round-trips naive; Postgres returns it aware. The endpoint
+    normalizes the same way before comparing, so this mirrors production
+    behaviour rather than papering over a bug.
+    """
+    dt = datetime.fromisoformat(value)
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+async def _authenticates(client, token) -> bool:
+    r = await client.get("/api/v1/workspaces", headers=_h(token))
+    assert r.status_code in (200, 401), r.text
+    return r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_both_secrets_work_during_the_overlap(auth_client, admin_token, default_bu):
+    """The entire point of the feature.
+
+    `regenerate` kills the old secret instantly, which is unusable when the same
+    key lives in CI, a laptop keychain and a cron job — you cannot update all
+    three atomically. During the window both must authenticate.
+    """
+    old = await _mint(auth_client, admin_token, name="ci", capability="read")
+    rotated = await _rotate(auth_client, admin_token, old["id"], overlap_hours=24)
+
+    assert rotated["token"] != old["token"]
+    assert await _authenticates(auth_client, old["token"]), "old secret died immediately"
+    assert await _authenticates(auth_client, rotated["token"]), "new secret does not work"
+
+
+@pytest.mark.asyncio
+async def test_rotation_sets_the_predecessor_deadline(auth_client, admin_token, default_bu):
+    old = await _mint(auth_client, admin_token, name="ci")
+    before = datetime.now(timezone.utc)
+    rotated = await _rotate(auth_client, admin_token, old["id"], overlap_hours=6)
+
+    assert rotated["predecessor_id"] == old["id"]
+    deadline = _as_utc(rotated["predecessor_expires_at"])
+    delta = deadline - before
+    assert timedelta(hours=5, minutes=55) < delta < timedelta(hours=6, minutes=5)
+
+
+@pytest.mark.asyncio
+async def test_old_key_stops_working_once_the_window_closes(
+    auth_client, admin_token, default_bu, _setup_db
+):
+    """No sweeper needed: the overlap rides the existing `expires_at` check."""
+    from app.models.api_key import APIKey
+
+    old = await _mint(auth_client, admin_token, name="ci")
+    await _rotate(auth_client, admin_token, old["id"], overlap_hours=1)
+    assert await _authenticates(auth_client, old["token"])
+
+    # Wind the clock past the window rather than sleeping through it.
+    async with _setup_db() as session:
+        row = await session.get(APIKey, old["id"])
+        row.expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+        await session.commit()
+
+    assert not await _authenticates(auth_client, old["token"]), "expired key still works"
+
+
+@pytest.mark.asyncio
+async def test_zero_overlap_is_an_immediate_cutover(auth_client, admin_token, default_bu):
+    old = await _mint(auth_client, admin_token, name="ci")
+    rotated = await _rotate(auth_client, admin_token, old["id"], overlap_hours=0)
+    assert not await _authenticates(auth_client, old["token"])
+    assert await _authenticates(auth_client, rotated["token"])
+
+
+@pytest.mark.asyncio
+async def test_default_overlap_is_24h(auth_client, admin_token, default_bu):
+    old = await _mint(auth_client, admin_token, name="ci")
+    r = await auth_client.post(
+        f"/api/v1/api-keys/{old['id']}/rotate", json={}, headers=_h(admin_token)
+    )
+    assert r.status_code == 201, r.text
+    deadline = _as_utc(r.json()["predecessor_expires_at"])
+    assert timedelta(hours=23) < deadline - datetime.now(timezone.utc) < timedelta(hours=25)
+
+
+@pytest.mark.asyncio
+async def test_rotation_never_extends_a_shorter_expiry(auth_client, admin_token, default_bu):
+    """A key expiring in 2h must not gain 22 more hours by being rotated."""
+    soon = datetime.now(timezone.utc) + timedelta(hours=2)
+    old = await _mint(auth_client, admin_token, name="ci", expires_at=soon.isoformat())
+    rotated = await _rotate(auth_client, admin_token, old["id"], overlap_hours=24)
+    deadline = _as_utc(rotated["predecessor_expires_at"])
+    assert deadline <= soon + timedelta(seconds=1), "rotation extended the credential's life"
+
+
+@pytest.mark.asyncio
+async def test_successor_inherits_scope_and_owner(auth_client, admin_token, default_bu, _setup_db):
+    ws_id = await _seed_workspace(_setup_db) if "_seed_workspace" in globals() else None
+    old = await _mint(auth_client, admin_token, name="scoped", capability="plan")
+    rotated = await _rotate(auth_client, admin_token, old["id"])
+    for field in ("name", "capability", "business_unit_id", "user_id", "workspace_ids"):
+        assert rotated[field] == old[field], f"{field} not carried to the successor"
+
+
+@pytest.mark.asyncio
+async def test_successor_gets_a_clean_usage_trail(auth_client, admin_token, default_bu):
+    old = await _mint(auth_client, admin_token, name="ci")
+    await _authenticates(auth_client, old["token"])  # stamp last_used_at
+    rotated = await _rotate(auth_client, admin_token, old["id"])
+    assert rotated["last_used_at"] is None
+    assert rotated["rotated_at"] is None
+    assert rotated["superseded_by_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_predecessor_records_the_link(auth_client, admin_token, default_bu):
+    old = await _mint(auth_client, admin_token, name="ci")
+    rotated = await _rotate(auth_client, admin_token, old["id"])
+    r = await auth_client.get("/api/v1/api-keys", headers=_h(admin_token))
+    rows = {k["id"]: k for k in r.json()}
+    assert rows[old["id"]]["superseded_by_id"] == rotated["id"]
+    assert rows[old["id"]]["rotated_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_cannot_rotate_the_same_key_twice(auth_client, admin_token, default_bu):
+    """Chaining would leave several live secrets behind one name."""
+    old = await _mint(auth_client, admin_token, name="ci")
+    first = await _rotate(auth_client, admin_token, old["id"])
+    r = await auth_client.post(
+        f"/api/v1/api-keys/{old['id']}/rotate", json={}, headers=_h(admin_token)
+    )
+    assert r.status_code == 409
+    assert first["id"] in r.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_can_rotate_the_successor(auth_client, admin_token, default_bu):
+    old = await _mint(auth_client, admin_token, name="ci")
+    first = await _rotate(auth_client, admin_token, old["id"])
+    second = await _rotate(auth_client, admin_token, first["id"])
+    assert second["predecessor_id"] == first["id"]
+    assert await _authenticates(auth_client, second["token"])
+
+
+@pytest.mark.asyncio
+async def test_cannot_rotate_a_revoked_or_expired_key(auth_client, admin_token, default_bu, _setup_db):
+    from app.models.api_key import APIKey
+
+    revoked = await _mint(auth_client, admin_token, name="dead")
+    await auth_client.delete(f"/api/v1/api-keys/{revoked['id']}", headers=_h(admin_token))
+    r = await auth_client.post(
+        f"/api/v1/api-keys/{revoked['id']}/rotate", json={}, headers=_h(admin_token)
+    )
+    assert r.status_code == 409 and "revoked" in r.json()["detail"].lower()
+
+    stale = await _mint(auth_client, admin_token, name="old")
+    async with _setup_db() as session:
+        row = await session.get(APIKey, stale["id"])
+        row.expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+        await session.commit()
+    r = await auth_client.post(
+        f"/api/v1/api-keys/{stale['id']}/rotate", json={}, headers=_h(admin_token)
+    )
+    assert r.status_code == 409 and "expired" in r.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_overlap_hours_is_range_checked(auth_client, admin_token, default_bu):
+    old = await _mint(auth_client, admin_token, name="ci")
+    for bad in (-1, 24 * 7 + 1):
+        r = await auth_client.post(
+            f"/api/v1/api-keys/{old['id']}/rotate",
+            json={"overlap_hours": bad},
+            headers=_h(admin_token),
+        )
+        assert r.status_code == 422, f"overlap_hours={bad} accepted"
+
+
+@pytest.mark.asyncio
+async def test_rotation_is_audited(auth_client, admin_token, default_bu, _setup_db):
+    from sqlalchemy import select
+
+    from app.models.audit_log import AuditLog
+
+    old = await _mint(auth_client, admin_token, name="ci")
+    rotated = await _rotate(auth_client, admin_token, old["id"], overlap_hours=12)
+
+    async with _setup_db() as session:
+        rows = (await session.execute(
+            select(AuditLog).where(AuditLog.action == "api_key.rotate")
+        )).scalars().all()
+    assert len(rows) == 1
+    details = rows[0].details
+    assert details["successor_id"] == rotated["id"]
+    assert details["overlap_hours"] == 12
+    # The plaintext must never reach the audit log.
+    assert rotated["token"] not in str(details)
+
+
+@pytest.mark.asyncio
+async def test_rotation_is_scoped_to_the_bu(auth_client, admin_token, default_bu, _setup_db):
+    """A key in another BU must be invisible, not merely forbidden."""
+    from app.models.business_unit import BusinessUnit
+    from app.models.api_key import APIKey
+    from app.services import api_key_service as svc
+
+    other_bu, other_key = str(uuid.uuid4()), str(uuid.uuid4())
+    _, prefix, token_hash = svc.generate_token()
+    async with _setup_db() as session:
+        session.add(BusinessUnit(id=other_bu, slug="other-rot", name="Other"))
+        await session.commit()
+        me = (await session.execute(
+            __import__("sqlalchemy").select(APIKey).limit(1)
+        )).scalars().first()
+        session.add(APIKey(
+            id=other_key, name="foreign", token_prefix=prefix, token_hash=token_hash,
+            user_id=(me.user_id if me else None) or str(uuid.uuid4()),
+            business_unit_id=other_bu, capability="read",
+        ))
+        await session.commit()
+
+    r = await auth_client.post(
+        f"/api/v1/api-keys/{other_key}/rotate", json={}, headers=_h(admin_token)
+    )
+    assert r.status_code == 404

--- a/services/api/tests/test_workspace_tags.py
+++ b/services/api/tests/test_workspace_tags.py
@@ -1,0 +1,365 @@
+"""Key/value tags on workspaces: validation, filtering, bulk edit, discovery."""
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.usefixtures("default_aws_account")
+
+from app.models.business_unit import DEFAULT_BU_ID
+from app.services import workspace_tags as wt
+
+
+def _h(token, bu="default"):
+    return {"Authorization": f"Bearer {token}", "X-Business-Unit": bu}
+
+
+async def _seed(factory, specs, bu_id=DEFAULT_BU_ID):
+    """specs: [(name, tags_or_None), …] → {name: id}"""
+    from app.models.workspace import Workspace
+
+    out = {}
+    async with factory() as session:
+        for name, tags in specs:
+            ws_id = str(uuid.uuid4())
+            session.add(Workspace(
+                business_unit_id=bu_id, id=ws_id, name=name,
+                aws_account_id="123456789012", region="us-east-1",
+                environment="dev", tf_working_dir=f"a/b/{name}",
+                repo_url="https://example.com/x.git", tags=tags,
+            ))
+            out[name] = ws_id
+        await session.commit()
+    return out
+
+
+# ─── validation (pure) ──────────────────────────────────────────────────────
+
+
+def test_keys_are_lowercased():
+    """`Team` and `team` being distinct tags is a bug every tagging system
+    learns the hard way."""
+    assert wt.validate({"Team": "Payments"}) == {"team": "Payments"}
+
+
+def test_values_keep_their_case():
+    assert wt.validate({"owner": "Jane Doe"})["owner"] == "Jane Doe"
+
+
+def test_collision_after_normalization_is_rejected():
+    with pytest.raises(wt.TagError, match="duplicate"):
+        wt.validate({"Team": "a", "team": "b"})
+
+
+@pytest.mark.parametrize("bad", ["", " ", "-lead", "trail-", "has space", "UPPER!", "a" * 65])
+def test_invalid_keys_are_rejected(bad):
+    with pytest.raises(wt.TagError):
+        wt.validate({bad: "v"})
+
+
+def test_non_scalar_values_are_rejected():
+    with pytest.raises(wt.TagError, match="scalar"):
+        wt.validate({"team": {"nested": 1}})
+
+
+def test_scalars_are_coerced_to_strings():
+    assert wt.validate({"port": 8080, "on": True})["port"] == "8080"
+
+
+def test_tag_count_is_capped():
+    with pytest.raises(wt.TagError, match="at most"):
+        wt.validate({f"k{i}": "v" for i in range(wt.MAX_TAGS_PER_WORKSPACE + 1)})
+
+
+def test_oversized_value_is_rejected():
+    with pytest.raises(wt.TagError, match="exceeds"):
+        wt.validate({"k": "x" * (wt.VALUE_MAX + 1)})
+
+
+def test_filter_parsing():
+    assert wt.parse_filter("team=payments") == ("team", "payments")
+    assert wt.parse_filter("Team=Payments") == ("team", "Payments")
+    assert wt.parse_filter("owner") == ("owner", None)
+    with pytest.raises(wt.TagError):
+        wt.parse_filter("")
+
+
+def test_bare_key_matches_any_value():
+    assert wt.matches({"owner": "jane"}, [("owner", None)])
+    assert not wt.matches({"team": "x"}, [("owner", None)])
+
+
+def test_filters_are_anded():
+    tags = {"team": "pay", "tier": "prod"}
+    assert wt.matches(tags, [("team", "pay"), ("tier", "prod")])
+    assert not wt.matches(tags, [("team", "pay"), ("tier", "dev")])
+
+
+def test_untagged_matches_nothing_but_survives():
+    assert not wt.matches(None, [("team", None)])
+    assert wt.matches(None, [])
+
+
+def test_apply_edit_merges_per_key():
+    """The property that makes bulk edit safe: setting `team` across twenty
+    workspaces must not wipe the `owner` one of them carries."""
+    assert wt.apply_edit({"owner": "jane"}, {"team": "pay"}) == {"owner": "jane", "team": "pay"}
+
+
+def test_apply_edit_unsets_and_is_idempotent():
+    assert wt.apply_edit({"a": "1", "b": "2"}, None, ["a"]) == {"b": "2"}
+    assert wt.apply_edit({"b": "2"}, None, ["a"]) == {"b": "2"}
+
+
+def test_apply_edit_unset_is_case_insensitive():
+    assert wt.apply_edit({"team": "x"}, None, ["Team"]) == {}
+
+
+# ─── API: create / update ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_create_and_read_back_tags(auth_client, admin_token, default_aws_account):
+    r = await auth_client.post("/api/v1/workspaces", headers=_h(admin_token), json={
+        "name": "tagged", "environment": "dev", "aws_account_id": "123456789012",
+        "region": "us-east-1", "tf_working_dir": "a/b/tagged",
+        "repo_url": "https://example.com/x.git", "tags": {"Team": "payments"},
+    })
+    assert r.status_code == 201, r.text
+    assert r.json()["tags"] == {"team": "payments"}
+
+
+@pytest.mark.asyncio
+async def test_untagged_workspace_reports_an_empty_object_not_null(
+    auth_client, admin_token, _setup_db
+):
+    """Every consumer wants to iterate tags without a null guard."""
+    await _seed(_setup_db, [("plain", None)])
+    r = await auth_client.get("/api/v1/workspaces", headers=_h(admin_token))
+    assert next(w for w in r.json() if w["name"] == "plain")["tags"] == {}
+
+
+@pytest.mark.asyncio
+async def test_invalid_tags_on_create_are_a_400(auth_client, admin_token, default_aws_account):
+    r = await auth_client.post("/api/v1/workspaces", headers=_h(admin_token), json={
+        "name": "bad", "environment": "dev", "aws_account_id": "123456789012",
+        "region": "us-east-1", "tf_working_dir": "a/b/bad",
+        "repo_url": "https://example.com/x.git", "tags": {"has space": "v"},
+    })
+    assert r.status_code == 400
+    assert "invalid tag key" in r.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_put_replaces_the_whole_map_and_validates(auth_client, admin_token, _setup_db):
+    ids = await _seed(_setup_db, [("w", {"a": "1", "b": "2"})])
+    r = await auth_client.put(
+        f"/api/v1/workspaces/{ids['w']}", headers=_h(admin_token), json={"tags": {"c": "3"}}
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["tags"] == {"c": "3"}
+
+    bad = await auth_client.put(
+        f"/api/v1/workspaces/{ids['w']}", headers=_h(admin_token), json={"tags": {"BAD KEY": "x"}}
+    )
+    assert bad.status_code == 400
+
+
+# ─── API: filtering ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_filter_by_key_and_value(auth_client, admin_token, _setup_db):
+    await _seed(_setup_db, [
+        ("pay-prod", {"team": "payments", "tier": "prod"}),
+        ("pay-dev", {"team": "payments", "tier": "dev"}),
+        ("ops-prod", {"team": "ops", "tier": "prod"}),
+        ("bare", None),
+    ])
+    r = await auth_client.get("/api/v1/workspaces?tag=team=payments", headers=_h(admin_token))
+    assert {w["name"] for w in r.json()} == {"pay-prod", "pay-dev"}
+
+
+@pytest.mark.asyncio
+async def test_repeated_tag_params_are_anded(auth_client, admin_token, _setup_db):
+    await _seed(_setup_db, [
+        ("pay-prod", {"team": "payments", "tier": "prod"}),
+        ("pay-dev", {"team": "payments", "tier": "dev"}),
+    ])
+    r = await auth_client.get(
+        "/api/v1/workspaces?tag=team=payments&tag=tier=prod", headers=_h(admin_token)
+    )
+    assert {w["name"] for w in r.json()} == {"pay-prod"}
+
+
+@pytest.mark.asyncio
+async def test_bare_key_filter_matches_any_value(auth_client, admin_token, _setup_db):
+    await _seed(_setup_db, [("has", {"owner": "jane"}), ("hasnt", {"team": "x"})])
+    r = await auth_client.get("/api/v1/workspaces?tag=owner", headers=_h(admin_token))
+    assert {w["name"] for w in r.json()} == {"has"}
+
+
+@pytest.mark.asyncio
+async def test_no_tag_param_returns_everything(auth_client, admin_token, _setup_db):
+    await _seed(_setup_db, [("a", {"t": "1"}), ("b", None)])
+    r = await auth_client.get("/api/v1/workspaces", headers=_h(admin_token))
+    assert {w["name"] for w in r.json()} >= {"a", "b"}
+
+
+@pytest.mark.asyncio
+async def test_malformed_filter_is_a_400(auth_client, admin_token, _setup_db):
+    await _seed(_setup_db, [("a", {"t": "1"})])
+    r = await auth_client.get("/api/v1/workspaces?tag==novalue", headers=_h(admin_token))
+    assert r.status_code == 400
+
+
+# ─── API: bulk edit ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_bulk_set_merges_and_does_not_clobber(auth_client, admin_token, _setup_db):
+    """The whole reason `set` is a merge and not a replace."""
+    ids = await _seed(_setup_db, [("a", {"owner": "jane"}), ("b", {"tier": "prod"})])
+    r = await auth_client.post("/api/v1/workspaces/tags", headers=_h(admin_token), json={
+        "workspace_ids": list(ids.values()), "set": {"team": "payments"},
+    })
+    assert r.status_code == 200, r.text
+    assert r.json()["updated"] == 2
+    by_name = {w["name"]: w["tags"] for w in r.json()["workspaces"]}
+    assert by_name["a"] == {"owner": "jane", "team": "payments"}
+    assert by_name["b"] == {"tier": "prod", "team": "payments"}
+
+
+@pytest.mark.asyncio
+async def test_bulk_unset(auth_client, admin_token, _setup_db):
+    ids = await _seed(_setup_db, [("a", {"team": "x", "keep": "y"})])
+    r = await auth_client.post("/api/v1/workspaces/tags", headers=_h(admin_token), json={
+        "workspace_ids": [ids["a"]], "unset": ["team"],
+    })
+    assert r.status_code == 200, r.text
+    assert r.json()["workspaces"][0]["tags"] == {"keep": "y"}
+
+
+@pytest.mark.asyncio
+async def test_bulk_edit_persists(auth_client, admin_token, _setup_db):
+    """Guards the SQLAlchemy trap: mutating a JSON dict in place is not tracked."""
+    ids = await _seed(_setup_db, [("a", {"old": "1"})])
+    await auth_client.post("/api/v1/workspaces/tags", headers=_h(admin_token), json={
+        "workspace_ids": [ids["a"]], "set": {"new": "2"},
+    })
+    r = await auth_client.get(f"/api/v1/workspaces/{ids['a']}", headers=_h(admin_token))
+    assert r.json()["tags"] == {"old": "1", "new": "2"}
+
+
+@pytest.mark.asyncio
+async def test_bulk_edit_is_all_or_nothing(auth_client, admin_token, _setup_db):
+    """A partial bulk edit is worse than a rejected one — you can't tell which
+    half applied."""
+    ids = await _seed(_setup_db, [("a", {"x": "1"})])
+    ghost = str(uuid.uuid4())
+    r = await auth_client.post("/api/v1/workspaces/tags", headers=_h(admin_token), json={
+        "workspace_ids": [ids["a"], ghost], "set": {"team": "pay"},
+    })
+    assert r.status_code == 404
+    assert ghost in r.json()["detail"]
+
+    check = await auth_client.get(f"/api/v1/workspaces/{ids['a']}", headers=_h(admin_token))
+    assert check.json()["tags"] == {"x": "1"}, "a rejected batch still wrote"
+
+
+@pytest.mark.asyncio
+async def test_bulk_edit_cannot_reach_another_bu(auth_client, admin_token, _setup_db):
+    from app.models.business_unit import BusinessUnit
+
+    other = str(uuid.uuid4())
+    async with _setup_db() as session:
+        session.add(BusinessUnit(id=other, slug="other-tags", name="Other"))
+        await session.commit()
+    foreign = await _seed(_setup_db, [("foreign", {"a": "1"})], bu_id=other)
+
+    r = await auth_client.post("/api/v1/workspaces/tags", headers=_h(admin_token), json={
+        "workspace_ids": [foreign["foreign"]], "set": {"team": "pay"},
+    })
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_bulk_edit_with_nothing_to_do_is_a_400(auth_client, admin_token, _setup_db):
+    ids = await _seed(_setup_db, [("a", None)])
+    r = await auth_client.post("/api/v1/workspaces/tags", headers=_h(admin_token), json={
+        "workspace_ids": [ids["a"]],
+    })
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_bulk_edit_requires_operator(auth_client, viewer_token, _setup_db):
+    ids = await _seed(_setup_db, [("a", None)])
+    r = await auth_client.post("/api/v1/workspaces/tags", headers=_h(viewer_token), json={
+        "workspace_ids": [ids["a"]], "set": {"team": "x"},
+    })
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_bulk_edit_writes_one_audit_row_per_workspace(
+    auth_client, admin_token, _setup_db
+):
+    from sqlalchemy import select
+
+    from app.models.audit_log import AuditLog
+
+    ids = await _seed(_setup_db, [("a", None), ("b", None)])
+    await auth_client.post("/api/v1/workspaces/tags", headers=_h(admin_token), json={
+        "workspace_ids": list(ids.values()), "set": {"team": "pay"},
+    })
+    async with _setup_db() as session:
+        rows = (await session.execute(
+            select(AuditLog).where(AuditLog.action == "workspace.tags_bulk_edit")
+        )).scalars().all()
+    assert {r.resource_id for r in rows} == set(ids.values())
+
+
+# ─── API: discovery ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tag_index_counts_keys_and_values(auth_client, admin_token, _setup_db):
+    await _seed(_setup_db, [
+        ("a", {"team": "pay", "tier": "prod"}),
+        ("b", {"team": "pay"}),
+        ("c", {"team": "ops"}),
+        ("d", None),
+    ])
+    r = await auth_client.get("/api/v1/workspaces/tags", headers=_h(admin_token))
+    assert r.status_code == 200, r.text
+    idx = {k["key"]: k for k in r.json()}
+    assert idx["team"]["count"] == 3
+    # values sorted by descending usage
+    assert [v["value"] for v in idx["team"]["values"]] == ["pay", "ops"]
+    assert idx["team"]["values"][0]["count"] == 2
+    assert idx["tier"]["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_tag_index_is_bu_scoped(auth_client, admin_token, _setup_db):
+    from app.models.business_unit import BusinessUnit
+
+    other = str(uuid.uuid4())
+    async with _setup_db() as session:
+        session.add(BusinessUnit(id=other, slug="other-idx", name="Other"))
+        await session.commit()
+    await _seed(_setup_db, [("mine", {"visible": "1"})])
+    await _seed(_setup_db, [("theirs", {"secret": "1"})], bu_id=other)
+
+    r = await auth_client.get("/api/v1/workspaces/tags", headers=_h(admin_token))
+    keys = {k["key"] for k in r.json()}
+    assert "visible" in keys and "secret" not in keys
+
+
+@pytest.mark.asyncio
+async def test_tags_route_is_not_shadowed_by_the_id_route(auth_client, admin_token, _setup_db):
+    """`/workspaces/tags` must not be parsed as workspace id "tags"."""
+    await _seed(_setup_db, [("a", {"t": "1"})])
+    r = await auth_client.get("/api/v1/workspaces/tags", headers=_h(admin_token))
+    assert r.status_code == 200
+    assert isinstance(r.json(), list)

--- a/services/cli/api_contract.json
+++ b/services/cli/api_contract.json
@@ -94,6 +94,16 @@
     },
     {
       "method": "GET",
+      "path": "/workspaces/tags",
+      "used_by": "tdt ws tags"
+    },
+    {
+      "method": "POST",
+      "path": "/workspaces/tags",
+      "used_by": "tdt ws tag"
+    },
+    {
+      "method": "GET",
       "path": "/runs",
       "used_by": "tdt run list, tdt context"
     },

--- a/services/cli/tdt/commands/ws_cmd.py
+++ b/services/cli/tdt/commands/ws_cmd.py
@@ -52,13 +52,85 @@ def resolve_workspace(obj: AppCtx, ref: str) -> dict:
 def ws_list(
     ctx: typer.Context,
     env: str | None = typer.Option(None, "--env", help="Filter by environment (client-side)."),
+    tag: list[str] | None = typer.Option(
+        None, "--tag", "-t",
+        help="Filter by tag, repeatable and AND-ed: -t team=payments -t tier=prod. "
+             "A bare key (-t owner) matches any value.",
+    ),
 ) -> None:
     """List workspaces in the current BU."""
     obj: AppCtx = ctx.obj
-    rows = obj.client.get("/workspaces") or []
+    params = {"tag": list(tag)} if tag else None
+    rows = obj.client.get("/workspaces", params=params) or []
     if env:
         rows = [r for r in rows if str(r.get("environment", "")).lower() == env.lower()]
     render(obj.fmt, rows, _COLUMNS, empty="No workspaces in this BU.")
+
+
+@app.command("tags")
+def ws_tags(ctx: typer.Context) -> None:
+    """Every tag key in this BU, with values and usage counts."""
+    obj: AppCtx = ctx.obj
+    keys = obj.client.get("/workspaces/tags") or []
+    if obj.fmt is Fmt.json:
+        render(obj.fmt, keys)
+        return
+    rows = [
+        {
+            "key": k["key"],
+            "used": k["count"],
+            "values": ", ".join(f"{v['value']} ({v['count']})" for v in k["values"][:6])
+            + (" …" if len(k["values"]) > 6 else ""),
+        }
+        for k in keys
+    ]
+    render(obj.fmt, rows, [("KEY", "key"), ("USED", "used"), ("VALUES", "values")],
+           empty="No tags in this BU.")
+
+
+@app.command("tag")
+def ws_tag(
+    ctx: typer.Context,
+    workspaces: list[str] = typer.Argument(..., help="Workspace ids or names."),
+    set_: list[str] | None = typer.Option(
+        None, "--set", "-s", help="key=value, repeatable. Merges — other tags are kept.",
+    ),
+    unset: list[str] | None = typer.Option(
+        None, "--unset", "-u", help="Tag key to remove, repeatable.",
+    ),
+) -> None:
+    """Set or remove tags across one or more workspaces.
+
+    `--set` merges per key, so tagging a batch's `team` never wipes the `owner`
+    tag one of them happens to carry. The whole batch is rejected if any
+    workspace is outside this BU — a half-applied bulk edit is worse than none.
+    """
+    obj: AppCtx = ctx.obj
+    if not set_ and not unset:
+        raise TdtError("Give at least one --set or --unset.", ExitCode.USAGE)
+
+    pairs: dict[str, str] = {}
+    for item in set_ or []:
+        if "=" not in item:
+            raise TdtError(f"--set expects key=value, got '{item}'.", ExitCode.USAGE)
+        key, _, value = item.partition("=")
+        pairs[key.strip()] = value.strip()
+
+    ids = [resolve_workspace(obj, ref)["id"] for ref in workspaces]
+    result = obj.client.post(
+        "/workspaces/tags",
+        {"workspace_ids": ids, "set": pairs, "unset": list(unset or [])},
+    )
+    if obj.fmt is Fmt.json:
+        render(obj.fmt, result)
+        return
+    ok(f"Updated {result['updated']} workspace(s).")
+    render(
+        obj.fmt,
+        [{"name": w["name"], "tags": ", ".join(f"{k}={v}" for k, v in sorted((w["tags"] or {}).items())) or "—"}
+         for w in result["workspaces"]],
+        [("NAME", "name"), ("TAGS", "tags")],
+    )
 
 
 @app.command("get")

--- a/services/cli/tdt/skill_asset/SKILL.md
+++ b/services/cli/tdt/skill_asset/SKILL.md
@@ -64,6 +64,9 @@ tdt run destroy <workspace> --yes --auto-approve --max-destroy 1
 ```bash
 tdt context -o json                  # one-shot BU snapshot: workspaces, recent runs, drift
 tdt ws list                          # add -o json for ids
+tdt ws list -t team=payments         # filter by tag; repeatable and AND-ed
+tdt ws tags                          # every tag key in the BU, with counts
+tdt ws tag <ws> -s team=payments     # set/unset tags; --set merges, never clobbers
 tdt run list -w <workspace> --status failed -n 5
 tdt run get <run-id>
 tdt run graph <run-id>               # the +/~/-/± diff and changed addresses

--- a/services/ui/src/api/apiKeys.ts
+++ b/services/ui/src/api/apiKeys.ts
@@ -15,6 +15,10 @@ export interface ApiKey {
   last_used_at?: string | null;
   expires_at?: string | null;
   revoked_at?: string | null;
+  // Set when a rotation superseded this key; `expires_at` is then the end of
+  // its overlap window rather than an expiry someone chose.
+  rotated_at?: string | null;
+  superseded_by_id?: string | null;
 }
 
 export interface ApiKeyCreate {
@@ -43,9 +47,31 @@ export async function revokeApiKey(id: string): Promise<void> {
   await api.delete(`/v1/api-keys/${id}`);
 }
 
-// Rotate a key's secret in place — same name/capability/scope/expiry, fresh
+// Replace a key's secret in place — same name/capability/scope/expiry, fresh
 // token (returned once, like creation). The old token stops working at once.
+// Use this only when a single consumer holds the key.
 export async function regenerateApiKey(id: string): Promise<ApiKeyCreated> {
   const res = await api.post<ApiKeyCreated>(`/v1/api-keys/${id}/regenerate`, {});
+  return res.data;
+}
+
+// Returned once by a rotation: the successor key, plus the deadline for
+// retiring the one it replaced.
+export interface ApiKeyRotated extends ApiKeyCreated {
+  predecessor_id: string;
+  predecessor_expires_at?: string | null;
+}
+
+// Mint a successor and keep the old secret alive for `overlapHours`. Prefer
+// this over regenerate whenever more than one consumer holds the key — a CI
+// secret store, a laptop keychain and a cron job cannot be updated atomically,
+// so they need a window in which both secrets work.
+export async function rotateApiKey(
+  id: string,
+  overlapHours = 24,
+): Promise<ApiKeyRotated> {
+  const res = await api.post<ApiKeyRotated>(`/v1/api-keys/${id}/rotate`, {
+    overlap_hours: overlapHours,
+  });
   return res.data;
 }

--- a/services/ui/src/components/TagChip.test.tsx
+++ b/services/ui/src/components/TagChip.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { TagChip, TagList } from "./TagChip";
+
+describe("TagChip", () => {
+  it("renders key and value", () => {
+    render(<TagChip tagKey="team" value="payments" />);
+    expect(screen.getByText("team")).toBeTruthy();
+    expect(screen.getByText("payments")).toBeTruthy();
+  });
+
+  it("omits the = for a valueless tag", () => {
+    const { container } = render(<TagChip tagKey="deprecated" value="" />);
+    expect(container.textContent).toBe("deprecated");
+  });
+
+  it("is a plain span when not clickable", () => {
+    const { container } = render(<TagChip tagKey="team" value="pay" />);
+    expect(container.querySelector("button")).toBeNull();
+  });
+
+  it("is a real button when clickable, so it is keyboard reachable", () => {
+    render(<TagChip tagKey="team" value="pay" onClick={() => {}} />);
+    expect(screen.getByRole("button")).toBeTruthy();
+  });
+
+  it("reports pressed state for screen readers", () => {
+    render(<TagChip tagKey="team" value="pay" onClick={() => {}} active />);
+    expect(screen.getByRole("button").getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+  });
+
+  it("does not bubble to the row underneath", () => {
+    // The row is clickable (expand/collapse); filtering must not also toggle it.
+    const onRow = vi.fn();
+    const onTag = vi.fn();
+    render(
+      <div onClick={onRow}>
+        <TagChip tagKey="team" value="pay" onClick={onTag} />
+      </div>,
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(onTag).toHaveBeenCalledWith("team", "pay");
+    expect(onRow).not.toHaveBeenCalled();
+  });
+});
+
+describe("TagList", () => {
+  it("renders nothing when there are no tags", () => {
+    const { container } = render(<TagList tags={{}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("survives null tags", () => {
+    const { container } = render(<TagList tags={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("sorts by key so a row always reads the same way", () => {
+    const { container } = render(<TagList tags={{ zebra: "1", alpha: "2" }} />);
+    const text = container.textContent ?? "";
+    expect(text.indexOf("alpha")).toBeLessThan(text.indexOf("zebra"));
+  });
+
+  it("collapses the overflow instead of wrapping unbounded", () => {
+    render(
+      <TagList tags={{ a: "1", b: "2", c: "3", d: "4", e: "5" }} max={3} />,
+    );
+    expect(screen.getByText("+2")).toBeTruthy();
+  });
+
+  it("puts the hidden tags in the overflow tooltip", () => {
+    render(<TagList tags={{ a: "1", b: "2", c: "3", d: "4" }} max={3} />);
+    expect(screen.getByText("+1").getAttribute("title")).toBe("d=4");
+  });
+
+  it("marks the chip matching the active filter", () => {
+    render(
+      <TagList
+        tags={{ team: "pay", tier: "prod" }}
+        onTagClick={() => {}}
+        activeTag={{ key: "team", value: "pay" }}
+      />,
+    );
+    const pressed = screen
+      .getAllByRole("button")
+      .filter((b) => b.getAttribute("aria-pressed") === "true");
+    expect(pressed).toHaveLength(1);
+    expect(pressed[0].textContent).toContain("pay");
+  });
+
+  it("a bare-key filter marks every value of that key", () => {
+    render(
+      <TagList
+        tags={{ owner: "jane" }}
+        onTagClick={() => {}}
+        activeTag={{ key: "owner", value: null }}
+      />,
+    );
+    expect(screen.getByRole("button").getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+  });
+});

--- a/services/ui/src/components/TagChip.tsx
+++ b/services/ui/src/components/TagChip.tsx
@@ -1,0 +1,133 @@
+import { cx } from "./ui";
+
+/**
+ * A workspace tag rendered as `key=value`.
+ *
+ * Deliberately monochrome, unlike AccountTag: a workspace can carry a dozen
+ * tags, and a dozen coloured chips on one row reads as noise and steals the
+ * colour channel the account rail already owns. The key is dimmed and the value
+ * is not, because in a list of `team=payments` / `team=ops` the value is the
+ * part you scan for.
+ *
+ * Clicking filters, so it is a <button> — a chip that changes what you see and
+ * isn't keyboard-reachable is a trap for anyone not using a mouse.
+ */
+export function TagChip({
+  tagKey,
+  value,
+  onClick,
+  active,
+  className,
+}: {
+  tagKey: string;
+  value: string;
+  /** Omit to render a static chip (no hover, no focus ring, not tabbable). */
+  onClick?: (tagKey: string, value: string) => void;
+  active?: boolean;
+  className?: string;
+}) {
+  const body = (
+    <>
+      <span className="text-slate-500 dark:text-slate-400">{tagKey}</span>
+      {value !== "" && (
+        <>
+          <span className="text-slate-400 dark:text-slate-500">=</span>
+          <span className="font-medium">{value}</span>
+        </>
+      )}
+    </>
+  );
+
+  const base = cx(
+    "inline-flex max-w-[16rem] items-center gap-0.5 truncate rounded px-1.5 py-0.5",
+    "font-mono text-[10px] leading-4",
+    active
+      ? "bg-brand-500/15 text-brand-700 ring-1 ring-brand-500/40 dark:text-brand-200"
+      : "bg-slate-500/10 text-slate-700 dark:text-slate-300",
+    className,
+  );
+
+  if (!onClick) {
+    return (
+      <span className={base} title={`${tagKey}=${value}`}>
+        {body}
+      </span>
+    );
+  }
+  return (
+    <button
+      type="button"
+      className={cx(
+        base,
+        "transition hover:bg-slate-500/20 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-500",
+      )}
+      title={
+        active
+          ? `Clear filter ${tagKey}=${value}`
+          : `Filter by ${tagKey}=${value}`
+      }
+      aria-pressed={active}
+      onClick={(e) => {
+        // The row itself is clickable (expand/collapse); filtering shouldn't
+        // also toggle the row open.
+        e.stopPropagation();
+        onClick(tagKey, value);
+      }}
+    >
+      {body}
+    </button>
+  );
+}
+
+/**
+ * A workspace's tags, sorted by key so the same workspace always reads the same
+ * way, with an overflow marker rather than an unbounded wrap.
+ */
+export function TagList({
+  tags,
+  max = 3,
+  onTagClick,
+  activeTag,
+  className,
+}: {
+  tags: Record<string, string> | null | undefined;
+  /** Chips shown before collapsing into "+N". */
+  max?: number;
+  onTagClick?: (tagKey: string, value: string) => void;
+  activeTag?: { key: string; value: string | null } | null;
+  className?: string;
+}) {
+  const entries = Object.entries(tags ?? {}).sort(([a], [b]) =>
+    a.localeCompare(b),
+  );
+  if (entries.length === 0) return null;
+
+  const shown = entries.slice(0, max);
+  const hidden = entries.slice(max);
+
+  return (
+    <span className={cx("inline-flex flex-wrap items-center gap-1", className)}>
+      {shown.map(([k, v]) => (
+        <TagChip
+          key={k}
+          tagKey={k}
+          value={v}
+          onClick={onTagClick}
+          active={
+            !!activeTag &&
+            activeTag.key === k &&
+            (activeTag.value === null || activeTag.value === v)
+          }
+        />
+      ))}
+      {hidden.length > 0 && (
+        <span
+          className="rounded bg-slate-500/10 px-1.5 py-0.5 font-mono text-[10px] leading-4 text-slate-500 dark:text-slate-400"
+          title={hidden.map(([k, v]) => `${k}=${v}`).join("\n")}
+        >
+          +{hidden.length}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/services/ui/src/components/WorkspaceTree.tsx
+++ b/services/ui/src/components/WorkspaceTree.tsx
@@ -4,8 +4,19 @@
 // public entry point and orchestrates grouping.
 import { useMemo, useState } from "react";
 import { Card, Input } from "./ui";
-import { AccountGroup, AzureSubscriptionGroup, GcpProjectGroup } from "./workspace-tree/groups";
-import { azureInfo, gcpInfo, workspacePathSegments } from "./workspace-tree/paths";
+import {
+  AccountGroup,
+  AzureSubscriptionGroup,
+  GcpProjectGroup,
+} from "./workspace-tree/groups";
+import {
+  azureInfo,
+  gcpInfo,
+  workspacePathSegments,
+} from "./workspace-tree/paths";
+import { TagChip } from "./TagChip";
+import { TagFilterContext, type ActiveTag } from "./workspace-tree/tagFilter";
+import { matchesTag, tagsAsSearchText } from "./workspace-tree/tagMatch";
 import type {
   AwsAccountLite,
   AzureSubscriptionLite,
@@ -16,7 +27,13 @@ import type {
 } from "./workspace-tree/types";
 
 // Public surface preserved for existing importers (Dashboard, Settings).
-export type { AwsAccountLite, AzureSubscriptionLite, GcpProjectLite, Run, Workspace };
+export type {
+  AwsAccountLite,
+  AzureSubscriptionLite,
+  GcpProjectLite,
+  Run,
+  Workspace,
+};
 export { azureInfo, gcpInfo, workspacePathSegments };
 
 export default function WorkspaceTree({
@@ -35,6 +52,11 @@ export default function WorkspaceTree({
   onChanged: () => void;
 }) {
   const [filter, setFilter] = useState("");
+  // Tag filter, set by clicking a chip on any row. Separate from the text box:
+  // the text box is fuzzy ("payments" also matches a workspace called
+  // payments-api), a tag filter is exact, and mixing the two into one input
+  // makes "why is this row here?" unanswerable.
+  const [activeTag, setActiveTag] = useState<ActiveTag>(null);
   const [expandSignal, setExpandSignal] = useState<ExpandSignal>(null);
 
   const accountNameById = useMemo(() => {
@@ -101,12 +123,20 @@ export default function WorkspaceTree({
     const info = azureInfo(w);
     if (info) {
       const sub = azureByGuid.get(info.guid);
-      return { cloud: "azure", key: sub ? sub.id : `guid:${info.guid}`, region: info.region };
+      return {
+        cloud: "azure",
+        key: sub ? sub.id : `guid:${info.guid}`,
+        region: info.region,
+      };
     }
     const ginfo = gcpInfo(w);
     if (ginfo) {
       const proj = gcpByProjectId.get(ginfo.projectId);
-      return { cloud: "gcp", key: proj ? proj.id : `pid:${ginfo.projectId}`, region: ginfo.region };
+      return {
+        cloud: "gcp",
+        key: proj ? proj.id : `pid:${ginfo.projectId}`,
+        region: ginfo.region,
+      };
     }
     return { cloud: "aws", key: w.aws_account_id, region: w.region };
   }
@@ -122,7 +152,9 @@ export default function WorkspaceTree({
   }, [workspaces]);
 
   const latestByWs = useMemo(() => {
-    const sorted = runs.slice().sort((a, b) => (a.created_at ?? "").localeCompare(b.created_at ?? ""));
+    const sorted = runs
+      .slice()
+      .sort((a, b) => (a.created_at ?? "").localeCompare(b.created_at ?? ""));
     sorted.reverse();
     const map = new Map<string, Run>();
     for (const r of sorted) {
@@ -136,9 +168,13 @@ export default function WorkspaceTree({
   }, [runs, wsById]);
 
   const filtered = useMemo(() => {
-    if (!filter.trim()) return workspaces;
+    // Tag filter first — it's exact and cheap, and narrowing before the string
+    // build means the text scan runs over fewer rows.
+    let pool = workspaces;
+    if (activeTag) pool = pool.filter((w) => matchesTag(w, activeTag));
+    if (!filter.trim()) return pool;
     const q = filter.trim().toLowerCase();
-    return workspaces.filter((w) => {
+    return pool.filter((w) => {
       const sub = w.azure_subscription_id
         ? azureByPk.get(w.azure_subscription_id)
         : azureByGuid.get(azureInfo(w)?.guid ?? "");
@@ -156,12 +192,24 @@ export default function WorkspaceTree({
         sub?.subscription_id ?? azureInfo(w)?.guid ?? "",
         proj?.name ?? "",
         proj?.project_id ?? gcpInfo(w)?.projectId ?? "",
+        // Tags join the fuzzy search as `key=value` pairs, so typing
+        // "payments" finds tagged workspaces without knowing the key.
+        tagsAsSearchText(w.tags),
       ]
         .join(" ")
         .toLowerCase()
         .includes(q);
     });
-  }, [workspaces, filter, accountNameById, azureByPk, azureByGuid, gcpByPk, gcpByProjectId]);
+  }, [
+    workspaces,
+    filter,
+    activeTag,
+    accountNameById,
+    azureByPk,
+    azureByGuid,
+    gcpByPk,
+    gcpByProjectId,
+  ]);
 
   // Group into AWS accounts, Azure subscriptions, and GCP projects; each →
   // region → workspaces[].
@@ -171,13 +219,15 @@ export default function WorkspaceTree({
     const gcp: Record<string, Record<string, Workspace[]>> = {};
     for (const w of filtered) {
       const c = classify(w);
-      const bucket = c.cloud === "azure" ? azure : c.cloud === "gcp" ? gcp : aws;
+      const bucket =
+        c.cloud === "azure" ? azure : c.cloud === "gcp" ? gcp : aws;
       const g = (bucket[c.key] ??= {});
       (g[c.region] ??= []).push(w);
     }
     for (const bucket of [aws, azure, gcp]) {
       for (const g of Object.values(bucket)) {
-        for (const region of Object.keys(g)) g[region].sort((a, b) => a.name.localeCompare(b.name));
+        for (const region of Object.keys(g))
+          g[region].sort((a, b) => a.name.localeCompare(b.name));
       }
     }
     return { awsGrouped: aws, azureGrouped: azure, gcpGrouped: gcp };
@@ -200,102 +250,150 @@ export default function WorkspaceTree({
   });
   const groupCount = accountIds.length + azureKeys.length + gcpKeys.length;
 
-  return (
-    <div className="space-y-4">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <Input
-          value={filter}
-          onChange={(e) => setFilter(e.target.value)}
-          placeholder="Filter by name, account, region, env…"
-          className="max-w-sm"
-        />
-        <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500">
-          <div className="inline-flex items-center gap-1">
-            <button
-              type="button"
-              onClick={() =>
-                setExpandSignal((s) => ({ version: (s?.version ?? 0) + 1, expand: true }))
-              }
-              className="rounded-md border border-slate-200 bg-white px-2 py-1 text-[11px] font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
-              title="Expand every account, region, and folder"
-            >
-              Expand all
-            </button>
-            <button
-              type="button"
-              onClick={() =>
-                setExpandSignal((s) => ({ version: (s?.version ?? 0) + 1, expand: false }))
-              }
-              className="rounded-md border border-slate-200 bg-white px-2 py-1 text-[11px] font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
-              title="Collapse every account, region, and folder"
-            >
-              Collapse all
-            </button>
-          </div>
-          <span>
-            {filtered.length} of {workspaces.length} workspace{workspaces.length === 1 ? "" : "s"}
-            {filter && (
-              <button onClick={() => setFilter("")} className="ml-2 underline-offset-2 hover:underline">
-                clear
-              </button>
-            )}
-          </span>
-        </div>
-      </div>
+  // Clicking the chip that is already filtering clears it, so the same gesture
+  // is both apply and undo — no hunting for an X.
+  const toggleTag = (key: string, value: string) =>
+    setActiveTag((cur) =>
+      cur && cur.key === key && cur.value === value ? null : { key, value },
+    );
 
-      {groupCount === 0 ? (
-        <Card className="px-6 py-10 text-center text-sm text-slate-500">
-          No workspaces match the current filter.
-        </Card>
-      ) : (
-        <div className="space-y-4">
-          {accountIds.map((accountId) => (
-            <AccountGroup
-              key={`aws:${accountId}`}
-              accountId={accountId}
-              accountName={accountNameById.get(accountId)}
-              byRegion={awsGrouped[accountId]}
-              latestByWs={latestByWs}
-              defaultOpen={false}
-              onChanged={onChanged}
-              expandSignal={expandSignal}
-              awsAccounts={awsAccounts}
-              azureSubscriptions={azureSubscriptions}
-              gcpProjects={gcpProjects}
+  return (
+    <TagFilterContext.Provider value={{ activeTag, onTagClick: toggleTag }}>
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <Input
+              value={filter}
+              onChange={(e) => setFilter(e.target.value)}
+              placeholder="Filter by name, account, region, env, tag…"
+              className="max-w-sm"
             />
-          ))}
-          {azureKeys.map((key) => (
-            <AzureSubscriptionGroup
-              key={`azure:${key}`}
-              sub={azureByPk.get(key)}
-              guid={key.startsWith("guid:") ? key.slice("guid:".length) : undefined}
-              byRegion={azureGrouped[key]}
-              latestByWs={latestByWs}
-              defaultOpen={false}
-              onChanged={onChanged}
-              expandSignal={expandSignal}
-              awsAccounts={awsAccounts}
-              azureSubscriptions={azureSubscriptions}
-              gcpProjects={gcpProjects}
-            />
-          ))}
-          {gcpKeys.map((key) => (
-            <GcpProjectGroup
-              key={`gcp:${key}`}
-              proj={gcpByPk.get(key)}
-              projectId={key.startsWith("pid:") ? key.slice("pid:".length) : undefined}
-              byRegion={gcpGrouped[key]}
-              latestByWs={latestByWs}
-              defaultOpen={false}
-              onChanged={onChanged}
-              expandSignal={expandSignal}
-              awsAccounts={awsAccounts}
-              azureSubscriptions={azureSubscriptions}
-              gcpProjects={gcpProjects}
-            />
-          ))}
+            {activeTag && (
+              // Shown outside the tree as well as highlighted in it: with a
+              // filter applied the matching rows may all be scrolled out of view,
+              // and an invisible filter is how you end up believing a workspace
+              // has vanished.
+              <span className="inline-flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400">
+                <span>tag</span>
+                <TagChip
+                  tagKey={activeTag.key}
+                  value={activeTag.value ?? ""}
+                  active
+                />
+                <button
+                  type="button"
+                  onClick={() => setActiveTag(null)}
+                  className="underline-offset-2 hover:underline"
+                >
+                  clear
+                </button>
+              </span>
+            )}
+          </div>
+          <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500">
+            <div className="inline-flex items-center gap-1">
+              <button
+                type="button"
+                onClick={() =>
+                  setExpandSignal((s) => ({
+                    version: (s?.version ?? 0) + 1,
+                    expand: true,
+                  }))
+                }
+                className="rounded-md border border-slate-200 bg-white px-2 py-1 text-[11px] font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
+                title="Expand every account, region, and folder"
+              >
+                Expand all
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  setExpandSignal((s) => ({
+                    version: (s?.version ?? 0) + 1,
+                    expand: false,
+                  }))
+                }
+                className="rounded-md border border-slate-200 bg-white px-2 py-1 text-[11px] font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-200 dark:hover:bg-slate-800"
+                title="Collapse every account, region, and folder"
+              >
+                Collapse all
+              </button>
+            </div>
+            <span>
+              {filtered.length} of {workspaces.length} workspace
+              {workspaces.length === 1 ? "" : "s"}
+              {filter && (
+                <button
+                  onClick={() => setFilter("")}
+                  className="ml-2 underline-offset-2 hover:underline"
+                >
+                  clear
+                </button>
+              )}
+            </span>
+          </div>
         </div>
-      )}
-    </div>
+
+        {groupCount === 0 ? (
+          <Card className="px-6 py-10 text-center text-sm text-slate-500">
+            No workspaces match the current filter.
+          </Card>
+        ) : (
+          <div className="space-y-4">
+            {accountIds.map((accountId) => (
+              <AccountGroup
+                key={`aws:${accountId}`}
+                accountId={accountId}
+                accountName={accountNameById.get(accountId)}
+                byRegion={awsGrouped[accountId]}
+                latestByWs={latestByWs}
+                defaultOpen={false}
+                onChanged={onChanged}
+                expandSignal={expandSignal}
+                awsAccounts={awsAccounts}
+                azureSubscriptions={azureSubscriptions}
+                gcpProjects={gcpProjects}
+              />
+            ))}
+            {azureKeys.map((key) => (
+              <AzureSubscriptionGroup
+                key={`azure:${key}`}
+                sub={azureByPk.get(key)}
+                guid={
+                  key.startsWith("guid:")
+                    ? key.slice("guid:".length)
+                    : undefined
+                }
+                byRegion={azureGrouped[key]}
+                latestByWs={latestByWs}
+                defaultOpen={false}
+                onChanged={onChanged}
+                expandSignal={expandSignal}
+                awsAccounts={awsAccounts}
+                azureSubscriptions={azureSubscriptions}
+                gcpProjects={gcpProjects}
+              />
+            ))}
+            {gcpKeys.map((key) => (
+              <GcpProjectGroup
+                key={`gcp:${key}`}
+                proj={gcpByPk.get(key)}
+                projectId={
+                  key.startsWith("pid:") ? key.slice("pid:".length) : undefined
+                }
+                byRegion={gcpGrouped[key]}
+                latestByWs={latestByWs}
+                defaultOpen={false}
+                onChanged={onChanged}
+                expandSignal={expandSignal}
+                awsAccounts={awsAccounts}
+                azureSubscriptions={azureSubscriptions}
+                gcpProjects={gcpProjects}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </TagFilterContext.Provider>
   );
 }

--- a/services/ui/src/components/settings/ApiKeysSection.tsx
+++ b/services/ui/src/components/settings/ApiKeysSection.tsx
@@ -7,6 +7,7 @@ import {
   createApiKey,
   listApiKeys,
   regenerateApiKey,
+  rotateApiKey,
   revokeApiKey,
 } from "../../api/apiKeys";
 import { useBusinessUnits, useBusinessUnitSelection } from "../../hooks/useBusinessUnit";
@@ -23,6 +24,11 @@ import {
   Spinner,
   cx,
 } from "../ui";
+
+// Default overlap offered by the UI. The API accepts 0–168; a day is long
+// enough to update a CI secret and a laptop keychain without being long
+// enough that a leaked old token matters much.
+const ROTATE_OVERLAP_HOURS = 24;
 
 type WsLite = { id: string; name: string; environment?: string; region?: string };
 
@@ -79,7 +85,7 @@ export default function ApiKeysSection() {
 
   // Pending destructive action awaiting in-app confirmation (no native popups).
   const [confirmAction, setConfirmAction] = useState<
-    { kind: "revoke" | "regenerate"; key: ApiKey } | null
+    { kind: "revoke" | "regenerate" | "rotate"; key: ApiKey } | null
   >(null);
   const [actionBusy, setActionBusy] = useState(false);
 
@@ -148,16 +154,22 @@ export default function ApiKeysSection() {
       if (kind === "revoke") {
         await revokeApiKey(key.id);
         await load();
+      } else if (kind === "rotate") {
+        setCreated(await rotateApiKey(key.id, ROTATE_OVERLAP_HOURS));
+        await load();
       } else {
-        const rotated = await regenerateApiKey(key.id);
-        setCreated(rotated);
+        setCreated(await regenerateApiKey(key.id));
         await load();
       }
       setConfirmAction(null);
     } catch (e: any) {
       setErr(
         e?.response?.data?.detail ??
-          (kind === "revoke" ? "Revoke failed" : "Regenerate failed"),
+          (kind === "revoke"
+            ? "Revoke failed"
+            : kind === "rotate"
+              ? "Rotate failed"
+              : "Regenerate failed"),
       );
     } finally {
       setActionBusy(false);
@@ -372,6 +384,15 @@ export default function ApiKeysSection() {
                       <td className="py-2 pr-3 text-right">
                         {!revoked && (
                           <div className="flex justify-end gap-1">
+                            {!expired && !k.superseded_by_id && (
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                onClick={() => setConfirmAction({ kind: "rotate", key: k })}
+                              >
+                                Rotate
+                              </Button>
+                            )}
                             {!expired && (
                               <Button
                                 size="sm"
@@ -404,12 +425,25 @@ export default function ApiKeysSection() {
       <ConfirmDialog
         open={confirmAction !== null}
         tone={confirmAction?.kind === "revoke" ? "danger" : "warning"}
-        title={confirmAction?.kind === "revoke" ? "Revoke API key" : "Regenerate API key"}
+        title={
+          confirmAction?.kind === "revoke"
+            ? "Revoke API key"
+            : confirmAction?.kind === "rotate"
+              ? "Rotate API key"
+              : "Regenerate API key"
+        }
         message={
           confirmAction?.kind === "revoke" ? (
             <>
               Revoke API key <strong>"{confirmAction?.key.name}"</strong>? Automation using it will
               stop working immediately. This cannot be undone.
+            </>
+          ) : confirmAction?.kind === "rotate" ? (
+            <>
+              Rotate API key <strong>"{confirmAction?.key.name}"</strong>? A new token is issued and
+              shown once, and the current one keeps working for{" "}
+              <strong>{ROTATE_OVERLAP_HOURS} hours</strong> so you can move consumers over one at a
+              time. After that it stops on its own — nothing else to click.
             </>
           ) : (
             <>
@@ -419,7 +453,13 @@ export default function ApiKeysSection() {
             </>
           )
         }
-        confirmLabel={confirmAction?.kind === "revoke" ? "Revoke" : "Regenerate"}
+        confirmLabel={
+          confirmAction?.kind === "revoke"
+            ? "Revoke"
+            : confirmAction?.kind === "rotate"
+              ? "Rotate"
+              : "Regenerate"
+        }
         busy={actionBusy}
         onConfirm={runConfirmedAction}
         onCancel={() => setConfirmAction(null)}

--- a/services/ui/src/components/workspace-tree/WorkspaceLeafRow.tsx
+++ b/services/ui/src/components/workspace-tree/WorkspaceLeafRow.tsx
@@ -6,6 +6,8 @@ import { useEffect, useState, type ReactNode } from "react";
 import { api } from "../../api/client";
 import { useCurrentUser, hasMinRole } from "../../hooks/useAuth";
 import { Badge, Button, ConfirmDialog, cx, DriftBadge } from "../ui";
+import { TagChip, TagList } from "../TagChip";
+import { useTagFilter } from "./tagFilter";
 import { RunModal } from "../RunModal";
 import { FileIcon, HelmChip } from "./icons";
 import { azureInfo, gcpInfo } from "./paths";
@@ -30,7 +32,10 @@ function MetaRow({
 }) {
   return (
     <tr className="border-t border-slate-100 first:border-t-0 dark:border-slate-800/50">
-      <td className="whitespace-nowrap py-1.5 pr-4 align-top text-slate-400" title={title}>
+      <td
+        className="whitespace-nowrap py-1.5 pr-4 align-top text-slate-400"
+        title={title}
+      >
         {label}
       </td>
       <td className="w-full py-1.5 align-top">{children}</td>
@@ -58,6 +63,7 @@ export function WorkspaceLeafRow({
   gcpProjects: GcpProjectLite[];
 }) {
   const user = useCurrentUser();
+  const { onTagClick, activeTag } = useTagFilter();
   const [busy, setBusy] = useState<null | string>(null);
   const [err, setErr] = useState<string | null>(null);
   const [expanded, setExpanded] = useState(false);
@@ -86,7 +92,9 @@ export function WorkspaceLeafRow({
   // GCP mirror of the Azure link: auto-derived from the gcp/project-<id>/ path
   // or the explicit gcp_project_id link. Read-only in the row.
   const isGcp = !!workspace.gcp_project_id || !!gcpInfo(workspace);
-  const linkedGcpProject = gcpProjects.find((p) => p.id === workspace.gcp_project_id);
+  const linkedGcpProject = gcpProjects.find(
+    (p) => p.id === workspace.gcp_project_id,
+  );
 
   // State backend is constrained by which cloud the workspace is linked to: s3
   // always works; azureblob/gcs need a linked Azure subscription / GCP project.
@@ -100,7 +108,11 @@ export function WorkspaceLeafRow({
   const backendPinned = validBackends.size === 1;
 
   // ─── State-lock status (lazy-fetched on expand) ────────────────────────
-  type LockStatus = { held: boolean; run_id?: string | null; acquired_at?: string | null };
+  type LockStatus = {
+    held: boolean;
+    run_id?: string | null;
+    acquired_at?: string | null;
+  };
   const [lockStatus, setLockStatus] = useState<LockStatus | null>(null);
   const [releaseLockOpen, setReleaseLockOpen] = useState(false);
 
@@ -146,7 +158,9 @@ export function WorkspaceLeafRow({
     setErr(null);
     setBusy("webhook");
     try {
-      await api.put(`/v1/workspaces/${workspace.id}`, { webhook_enabled: next });
+      await api.put(`/v1/workspaces/${workspace.id}`, {
+        webhook_enabled: next,
+      });
       onChanged();
     } catch (e: any) {
       setErr(e?.response?.data?.detail ?? e?.message ?? "Update failed");
@@ -217,7 +231,9 @@ export function WorkspaceLeafRow({
     setErr(null);
     setBusy("delete");
     try {
-      await api.delete(`/v1/workspaces/${workspace.id}?force=true&delete_state=false`);
+      await api.delete(
+        `/v1/workspaces/${workspace.id}?force=true&delete_state=false`,
+      );
       onChanged();
     } catch (e: any) {
       setErr(e?.response?.data?.detail ?? e?.message ?? "Untrack failed");
@@ -226,13 +242,20 @@ export function WorkspaceLeafRow({
     }
   }
 
-  const isGitSynced = !!workspace.repo_url && !workspace.repo_url.startsWith("local://");
+  const isGitSynced =
+    !!workspace.repo_url && !workspace.repo_url.startsWith("local://");
   const isOrphaned = workspace.path_status === "orphaned";
   // Branch+status chip: color reflects the most recent run state on this
   // workspace (not the workspace itself). Operators pick branches inside the
   // Run modal — clicking the chip is intentionally a no-op, the chip is a
   // status indicator, not an action.
-  const chip = <BranchStatusChip branch={branch} run={recentRun} webhookEnabled={webhookEnabled} />;
+  const chip = (
+    <BranchStatusChip
+      branch={branch}
+      run={recentRun}
+      webhookEnabled={webhookEnabled}
+    />
+  );
 
   const isHelm = workspace.kind === "helm";
 
@@ -245,7 +268,14 @@ export function WorkspaceLeafRow({
           <Badge tone="warning">orphaned · path missing</Badge>
         </span>
       )}
-      {workspace.drift_status !== "unknown" && <DriftBadge status={workspace.drift_status} />}
+      {workspace.drift_status !== "unknown" && (
+        <DriftBadge status={workspace.drift_status} />
+      )}
+      <TagList
+        tags={workspace.tags}
+        onTagClick={onTagClick}
+        activeTag={activeTag}
+      />
       {hasMinRole(user, "operator") && !isOrphaned && (
         <>
           <Button
@@ -317,9 +347,13 @@ export function WorkspaceLeafRow({
         depth={depth}
         icon={<FileIcon />}
         label={<span className="font-medium">{displayName}</span>}
-        meta={workspace.tf_working_dir && workspace.tf_working_dir !== "." ? (
-          <span className="font-mono text-[11px]">{workspace.tf_working_dir}</span>
-        ) : null}
+        meta={
+          workspace.tf_working_dir && workspace.tf_working_dir !== "." ? (
+            <span className="font-mono text-[11px]">
+              {workspace.tf_working_dir}
+            </span>
+          ) : null
+        }
         right={right}
         onToggle={() => setExpanded((v) => !v)}
         open={expanded}
@@ -340,10 +374,43 @@ export function WorkspaceLeafRow({
               <table className="w-full border-collapse text-xs">
                 <tbody>
                   <MetaRow label="id">
-                    <span className="font-mono text-[11px]">{workspace.id}</span>
+                    <span className="font-mono text-[11px]">
+                      {workspace.id}
+                    </span>
                   </MetaRow>
                   <MetaRow label="region">
-                    <span className="font-mono text-[11px]">{workspace.region}</span>
+                    <span className="font-mono text-[11px]">
+                      {workspace.region}
+                    </span>
+                  </MetaRow>
+                  <MetaRow
+                    label="tags"
+                    title="Key/value labels. Click one to filter the tree. Edit with `tdt ws tag`, or PUT /workspaces/{id}."
+                  >
+                    {Object.keys(workspace.tags ?? {}).length === 0 ? (
+                      <span className="text-[11px] text-slate-400">—</span>
+                    ) : (
+                      // No `max` here: the collapsed row truncates, the detail
+                      // view is where you go to see all of them.
+                      <span className="inline-flex flex-wrap items-center gap-1">
+                        {Object.entries(workspace.tags ?? {})
+                          .sort(([a], [b]) => a.localeCompare(b))
+                          .map(([k, v]) => (
+                            <TagChip
+                              key={k}
+                              tagKey={k}
+                              value={v}
+                              onClick={onTagClick}
+                              active={
+                                !!activeTag &&
+                                activeTag.key === k &&
+                                (activeTag.value === null ||
+                                  activeTag.value === v)
+                              }
+                            />
+                          ))}
+                      </span>
+                    )}
                   </MetaRow>
                   <MetaRow
                     label="state aws account"
@@ -368,7 +435,9 @@ export function WorkspaceLeafRow({
                       monoSelect
                       canEdit={hasMinRole(user, "admin")}
                       busy={busy === "rebind-state"}
-                      onSave={(v) => saveLink("state_aws_account_id", v, "rebind-state")}
+                      onSave={(v) =>
+                        saveLink("state_aws_account_id", v, "rebind-state")
+                      }
                     />
                   </MetaRow>
                   {isAzure && (
@@ -408,7 +477,13 @@ export function WorkspaceLeafRow({
                         <select
                           value={currentBackend}
                           disabled={busy === "rebind-backend" || backendPinned}
-                          onChange={(e) => saveLink("state_backend", e.target.value, "rebind-backend")}
+                          onChange={(e) =>
+                            saveLink(
+                              "state_backend",
+                              e.target.value,
+                              "rebind-backend",
+                            )
+                          }
                           title={
                             backendPinned
                               ? "Pinned to s3 — link an Azure subscription or GCP project to enable an alternative state backend."
@@ -420,20 +495,34 @@ export function WorkspaceLeafRow({
                           )}
                         >
                           {["s3", "azureblob", "gcs"].map((b) => (
-                            <option key={b} value={b} disabled={!validBackends.has(b)}>
-                              {validBackends.has(b) ? b : `${b} · needs linked provider`}
+                            <option
+                              key={b}
+                              value={b}
+                              disabled={!validBackends.has(b)}
+                            >
+                              {validBackends.has(b)
+                                ? b
+                                : `${b} · needs linked provider`}
                             </option>
                           ))}
                         </select>
-                        {backendPinned && <span className="text-[10px] text-slate-400">pinned</span>}
+                        {backendPinned && (
+                          <span className="text-[10px] text-slate-400">
+                            pinned
+                          </span>
+                        )}
                       </span>
                     ) : (
-                      <span className="font-mono text-[11px]">{currentBackend}</span>
+                      <span className="font-mono text-[11px]">
+                        {currentBackend}
+                      </span>
                     )}
                   </MetaRow>
                   {workspace.repo_url && (
                     <MetaRow label="repo">
-                      <span className="break-all font-mono text-[11px]">{workspace.repo_url}</span>
+                      <span className="break-all font-mono text-[11px]">
+                        {workspace.repo_url}
+                      </span>
                     </MetaRow>
                   )}
                   {isGitSynced && (
@@ -463,7 +552,9 @@ export function WorkspaceLeafRow({
                   )}
                   {recentRun && (
                     <MetaRow label="last run">
-                      <span className="font-mono text-[11px]">{recentRun.id.slice(0, 8)}</span>{" "}
+                      <span className="font-mono text-[11px]">
+                        {recentRun.id.slice(0, 8)}
+                      </span>{" "}
                       <span>{recentRun.command}</span>
                     </MetaRow>
                   )}
@@ -480,7 +571,11 @@ export function WorkspaceLeafRow({
                       {(lockStatus.run_id ?? "unknown").slice(0, 8)}
                     </span>
                     {lockStatus.acquired_at && (
-                      <> · since {new Date(lockStatus.acquired_at).toLocaleTimeString()}</>
+                      <>
+                        {" "}
+                        · since{" "}
+                        {new Date(lockStatus.acquired_at).toLocaleTimeString()}
+                      </>
                     )}
                   </span>
                   {hasMinRole(user, "operator") && (
@@ -505,9 +600,11 @@ export function WorkspaceLeafRow({
         title="Force-release state lock"
         message={
           <>
-            This clears the terraform state lock for <span className="font-mono">{displayName}</span>.
-            Only do this if you're certain no executor is currently running against this workspace —
-            releasing under a live apply can let a concurrent run race state.
+            This clears the terraform state lock for{" "}
+            <span className="font-mono">{displayName}</span>. Only do this if
+            you're certain no executor is currently running against this
+            workspace — releasing under a live apply can let a concurrent run
+            race state.
           </>
         }
         confirmLabel="Release lock"
@@ -522,8 +619,9 @@ export function WorkspaceLeafRow({
         title="Delete workspace"
         message={
           <>
-            Delete workspace <span className="font-mono">{workspace.name}</span>? All runs, drift
-            reports, and state locks for this workspace will be removed.
+            Delete workspace <span className="font-mono">{workspace.name}</span>
+            ? All runs, drift reports, and state locks for this workspace will
+            be removed.
           </>
         }
         confirmLabel="Delete"
@@ -538,9 +636,11 @@ export function WorkspaceLeafRow({
         message={
           <div className="space-y-2.5">
             <p>
-              Force-delete orphaned workspace <span className="font-mono">{workspace.name}</span>?
-              The source path is missing from the repo, so a real terraform destroy isn't possible.
-              This removes the TDT row + all runs/drift reports/state locks.
+              Force-delete orphaned workspace{" "}
+              <span className="font-mono">{workspace.name}</span>? The source
+              path is missing from the repo, so a real terraform destroy isn't
+              possible. This removes the TDT row + all runs/drift reports/state
+              locks.
             </p>
             <label className="flex cursor-pointer items-start gap-2">
               <input
@@ -551,13 +651,16 @@ export function WorkspaceLeafRow({
                 className="mt-0.5 h-3.5 w-3.5"
               />
               <span>
-                Also delete the tfstate file in S3. You won't be able to recover this workspace by
-                re-importing. Leave unchecked to keep the tfstate (recommended).
+                Also delete the tfstate file in S3. You won't be able to recover
+                this workspace by re-importing. Leave unchecked to keep the
+                tfstate (recommended).
               </span>
             </label>
           </div>
         }
-        confirmLabel={forceDeleteState ? "Force delete + tfstate" : "Force delete"}
+        confirmLabel={
+          forceDeleteState ? "Force delete + tfstate" : "Force delete"
+        }
         tone="danger"
         busy={busy === "delete"}
         onConfirm={forceDeleteOrphan}
@@ -568,11 +671,12 @@ export function WorkspaceLeafRow({
         title="Untrack workspace"
         message={
           <>
-            Remove <span className="font-mono">{workspace.name}</span> from Terraducktel? This does{" "}
-            <b>not</b> run terraform destroy — the Terraform module stays in the repo and the real
-            infrastructure + tfstate are left untouched. TDT just stops tracking it (its runs, drift
-            reports, and state locks are cleared). It won't reappear on its own; re-import the path
-            to manage it again.
+            Remove <span className="font-mono">{workspace.name}</span> from
+            Terraducktel? This does <b>not</b> run terraform destroy — the
+            Terraform module stays in the repo and the real infrastructure +
+            tfstate are left untouched. TDT just stops tracking it (its runs,
+            drift reports, and state locks are cleared). It won't reappear on
+            its own; re-import the path to manage it again.
           </>
         }
         confirmLabel="Untrack"

--- a/services/ui/src/components/workspace-tree/tagFilter.tsx
+++ b/services/ui/src/components/workspace-tree/tagFilter.tsx
@@ -1,0 +1,24 @@
+import { createContext, useContext } from "react";
+
+/**
+ * The tree's active tag filter, shared with the leaf rows.
+ *
+ * A context rather than props: the only consumer is `WorkspaceLeafRow`, four
+ * levels below `WorkspaceTree` (tree → account/subscription/project group →
+ * folder body → leaf). Threading two props through three components that do
+ * not otherwise care about tags is a lot of noise for one feature, and every
+ * one of those signatures would need touching again for the next one.
+ *
+ * Default is inert, so a leaf rendered outside a provider (tests, Storybook)
+ * shows static chips instead of throwing.
+ */
+export type ActiveTag = { key: string; value: string | null } | null;
+
+export const TagFilterContext = createContext<{
+  activeTag: ActiveTag;
+  onTagClick?: (tagKey: string, value: string) => void;
+}>({ activeTag: null });
+
+export function useTagFilter() {
+  return useContext(TagFilterContext);
+}

--- a/services/ui/src/components/workspace-tree/tagMatch.test.ts
+++ b/services/ui/src/components/workspace-tree/tagMatch.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { matchesTag, tagsAsSearchText } from "./tagMatch";
+import type { Workspace } from "./types";
+
+const ws = (tags?: Record<string, string> | null): Workspace =>
+  ({
+    id: "w",
+    name: "w",
+    environment: "dev",
+    region: "us-east-1",
+    aws_account_id: "111111111111",
+    drift_status: "unknown",
+    tags,
+  }) as Workspace;
+
+describe("matchesTag", () => {
+  it("no filter matches everything", () => {
+    expect(matchesTag(ws({ a: "1" }), null)).toBe(true);
+    expect(matchesTag(ws(null), null)).toBe(true);
+  });
+
+  it("matches an exact key and value", () => {
+    expect(matchesTag(ws({ team: "pay" }), { key: "team", value: "pay" })).toBe(
+      true,
+    );
+    expect(matchesTag(ws({ team: "ops" }), { key: "team", value: "pay" })).toBe(
+      false,
+    );
+  });
+
+  it("a null value is a presence check", () => {
+    expect(
+      matchesTag(ws({ owner: "jane" }), { key: "owner", value: null }),
+    ).toBe(true);
+    expect(matchesTag(ws({ team: "pay" }), { key: "owner", value: null })).toBe(
+      false,
+    );
+  });
+
+  it("an untagged workspace matches no filter", () => {
+    expect(matchesTag(ws(null), { key: "team", value: null })).toBe(false);
+    expect(matchesTag(ws({}), { key: "team", value: "pay" })).toBe(false);
+  });
+
+  it("distinguishes an empty value from a missing key", () => {
+    // The API allows `key=` with an empty value; that is present, not absent.
+    expect(matchesTag(ws({ flag: "" }), { key: "flag", value: null })).toBe(
+      true,
+    );
+    expect(matchesTag(ws({ flag: "" }), { key: "flag", value: "" })).toBe(true);
+    expect(matchesTag(ws({ flag: "" }), { key: "flag", value: "x" })).toBe(
+      false,
+    );
+  });
+
+  it("is case sensitive on values, matching the API", () => {
+    // The API lowercases keys but preserves value case, so "Prod" !== "prod".
+    expect(
+      matchesTag(ws({ tier: "Prod" }), { key: "tier", value: "prod" }),
+    ).toBe(false);
+  });
+});
+
+describe("tagsAsSearchText", () => {
+  it("renders key=value pairs for the fuzzy search", () => {
+    expect(tagsAsSearchText({ team: "pay" })).toBe("team=pay");
+  });
+
+  it("is empty for no tags", () => {
+    expect(tagsAsSearchText(null)).toBe("");
+    expect(tagsAsSearchText({})).toBe("");
+  });
+
+  it("lets a value be found without knowing its key", () => {
+    expect(tagsAsSearchText({ team: "payments" }).includes("payments")).toBe(
+      true,
+    );
+  });
+});

--- a/services/ui/src/components/workspace-tree/tagMatch.ts
+++ b/services/ui/src/components/workspace-tree/tagMatch.ts
@@ -1,0 +1,30 @@
+import type { ActiveTag } from "./tagFilter";
+import type { Workspace } from "./types";
+
+/**
+ * Does this workspace satisfy the active tag filter?
+ *
+ * Mirrors `workspace_tags.matches()` on the API side: an exact value match, or
+ * presence-only when `value` is null. Kept as a pure function (like paths.ts)
+ * so the semantics are testable without mounting the tree — the filter silently
+ * hiding a row is the kind of bug you only notice by counting.
+ *
+ * The two implementations are deliberately duplicated rather than shared: the
+ * server filters `GET /workspaces?tag=`, the client filters an already-loaded
+ * list, and one of them has to exist in each language regardless.
+ */
+export function matchesTag(ws: Workspace, active: ActiveTag): boolean {
+  if (!active) return true;
+  const value = (ws.tags ?? {})[active.key];
+  if (value === undefined) return false;
+  return active.value === null || value === active.value;
+}
+
+/** `{team: "pay"}` → `"team=pay"`, for folding tags into the fuzzy text search. */
+export function tagsAsSearchText(
+  tags: Record<string, string> | null | undefined,
+): string {
+  return Object.entries(tags ?? {})
+    .map(([k, v]) => `${k}=${v}`)
+    .join(" ");
+}

--- a/services/ui/src/components/workspace-tree/types.ts
+++ b/services/ui/src/components/workspace-tree/types.ts
@@ -41,6 +41,11 @@ export type Workspace = {
   // pre-028 rows (no column yet) still render as terraform.
   kind?: string;
   cluster_id?: string | null;
+  // Free-form key/value tags, e.g. {"team": "payments"}. Keys are
+  // lowercased by the API. Always an object on the wire — an untagged
+  // workspace sends {} rather than null — but typed optional so older
+  // fixtures and pre-043 responses still satisfy the type.
+  tags?: Record<string, string> | null;
 };
 
 export type Run = {


### PR DESCRIPTION
Two independent features plus their UI.

## API-key rotation with an overlap window

`regenerate` swaps a key's secret **in place** and the old one dies that instant. Fine when exactly one consumer holds the key — useless when the same key sits in a CI secret store, a laptop keychain and a cron job, because you can't update all three atomically.

`POST /api-keys/{id}/rotate` mints a **successor** and leaves the old secret working for `overlap_hours` (default 24, max 168, `0` = immediate cutover).

Two rows, not one, because an overlap needs two usable secrets at once and `token_hash` is unique per row:

| | |
|---|---|
| **old key** | `expires_at` pulled in to `now + overlap_hours`, `rotated_at` set, `superseded_by_id` → successor |
| **new key** | same name, capability, workspace scope, owner and BU; fresh secret, returned once, clean `last_used_at` |

The window rides the **existing** `expires_at` check in `api_key_service.is_active()` — no new auth path, no sweeper job, the old key stops on its own.

Guard rails:
- **Never extends a shorter expiry.** A key expiring in 2h doesn't gain 22 more by being rotated.
- **A key can be rotated once.** Chaining would leave several live secrets behind one name; the 409 names the successor to rotate instead.
- Revoked/expired keys refused. `superseded_by_id` is `ON DELETE SET NULL` so deleting a successor can't erase its predecessor's history.
- The plaintext never reaches the audit log (asserted).

Verified against Postgres, since the SQLite suite can't prove the interesting part: both secrets return 200 simultaneously during the window.

## Workspace tags

`workspaces.tags`, a JSON key/value map:

| | |
|---|---|
| `GET /workspaces?tag=team=payments&tag=tier=prod` | repeatable, AND-ed. Bare `?tag=owner` matches any value |
| `GET /workspaces/tags` | key/value index with usage counts |
| `POST /workspaces/tags` | bulk set/unset |

**A JSON column, not a join table.** At this fleet size a dict scan gives what an index would, and it keeps tags atomic with the row they describe — no partial write, and no orphan cleanup on delete. Matching runs in Python because a JSON containment predicate isn't portable across SQLite and Postgres; the BU scope is still applied *in the query*.

Behaviours worth reviewing:
- **Keys are lowercased.** `Team` and `team` being distinct tags is a bug every tagging system learns the hard way. Values keep their case — they're display text.
- **`set` merges per key**, never replaces the map, so retagging twenty workspaces' `team` can't wipe the `owner` tag one of them carries.
- **Bulk edits are all-or-nothing.** A partially applied one is worse than a rejected one, because you can't tell which half landed.
- **`tags` is always an object in responses**, never null — `default_factory` alone doesn't do it (it fires on absence, not on an explicit NULL from the ORM), so a coercing validator handles it.
- Tags are reassigned, never mutated in place: SQLAlchemy doesn't track in-place edits to a JSON dict, so a mutation would silently not persist. There's a test for exactly that.

## UI + CLI

Rotate sits beside Regenerate, offered first as the safer default, hidden once a key is superseded.

Tags render as **monochrome** chips on every workspace row — a workspace can carry a dozen, and colour is already the account rail's channel. Clicking a chip filters the tree; clicking the active one clears it. Full list in the expanded row, and tags fold into the existing fuzzy search as `key=value`.

```bash
tdt ws tag <workspace> -s team=payments -s tier=prod
tdt ws list -t team=payments -t tier=prod
tdt ws tags
```

## Not included

Editing tags from the UI and multi-select bulk tagging — both endpoints exist, the selection UI is the real work.

## Tests

641 API · 179 CLI · 89 UI. Migration chain `041 → 042 → 043` verified linear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)