### PR TITLE
docs: MkDocs Material site published to /docs/

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -211,3 +211,75 @@ jobs:
       - name: Summary (no release)
         if: steps.t.outputs.release != 'true'
         run: echo "No release cut for this event." >> "$GITHUB_STEP_SUMMARY"
+
+  # ── docs site: publish docs/ to gh-pages under /docs/ ──────────────────────
+  docs:
+    name: Publish docs
+    needs: [api-tests, cli-tests, ui, release-version]
+    # Only from the repo's own default branch. A PR must still *build* the docs
+    # (the build step below runs on PRs via `mkdocs build --strict`), but only a
+    # merge publishes.
+    if: >-
+      github.event_name == 'push' &&
+      github.ref_name == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # push the built site to gh-pages
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install MkDocs
+        run: pip install mkdocs-material
+
+      - name: Build
+        run: mkdocs build --strict
+
+      - name: Publish to gh-pages/docs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # The landing page is a hand-written index.html at the root of
+          # gh-pages. `mkdocs gh-deploy` would replace the whole branch and take
+          # it with it, so the site is spliced into the `docs/` subtree instead
+          # and everything else on the branch is left alone.
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          tmp="$(mktemp -d)"
+          git worktree add --quiet "$tmp" gh-pages
+
+          rm -rf "$tmp/docs"
+          mkdir -p "$tmp/docs"
+          cp -R site/. "$tmp/docs/"
+          # Jekyll would otherwise swallow MkDocs' _-prefixed asset dirs.
+          touch "$tmp/.nojekyll"
+
+          cd "$tmp"
+          git add -A docs .nojekyll
+          if git diff --cached --quiet; then
+            echo "Docs unchanged."
+          else
+            git commit -m "docs: rebuild from ${GITHUB_SHA::8}"
+            git push origin gh-pages
+            echo "Published https://mormor83.github.io/terraducktel/docs/"
+          fi
+
+  # ── docs build check on PRs (no publish) ───────────────────────────────────
+  docs-build:
+    name: Docs build
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install mkdocs-material
+      # --strict turns a broken internal link or a page missing from the nav
+      # into a failure, which is the only way docs stay correct.
+      - run: mkdocs build --strict

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ services/api/.venv/
 services/cli/.venv/
 .coverage
 htmlcov/
+# MkDocs build output (see mkdocs.yml)
+site/

--- a/docs/API.md
+++ b/docs/API.md
@@ -186,7 +186,7 @@ policies in the BU. Every write requires a concrete `X-Business-Unit` — 400 if
 scoped to "all".
 
 Executor-facing: `GET /api/v1/runs/{run_id}/policies` (operator) returns the
-merged gate config + enabled policies for the run's BU — see [Runs](#runs--apiv1runs--apiv1workspacesidruns).
+merged gate config + enabled policies for the run's BU — see [Runs](#runs-apiv1runs-apiv1workspacesidruns).
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -140,7 +140,7 @@ forward-only (`services/api/alembic/versions/NNN_*.py`).
 | `Config` / `ConfigHistory` | `config` / `config_history` | Generic key/value runtime config (see [§6](#6-encryption-model)); every write is versioned in `config_history`. |
 | `GlobalVariable` / `WorkspaceVariable` | `global_variables` / `workspace_variables` | Encrypted `TF_VAR_*` sources at BU-global and per-workspace scope. Merge order at executor launch: `global ← workspace ← run` (run-scope values live inline on `Run.variables_encrypted`, not here). |
 | `AuditLog` | `audit_logs` | Append-only, hash-chained audit trail (see [§10](#10-webhooks-notifications-audit-log)). |
-| `APIKey` | `api_keys` | Scoped automation credential (see [§5](#5-auth--rbac)). |
+| `APIKey` | `api_keys` | Scoped automation credential (see [§5](#5-auth-rbac)). |
 | `ChangelogEntry` | `changelog_entries` | TDT-owned changelog shown in Settings → Changelog; rows are `github` (synced from merged PRs) or `manual` (admin-authored). |
 
 ---

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,174 @@
+# The `tdt` CLI
+
+`tdt` is how Terraducktel is meant to be driven from a terminal, from CI, and
+from an AI agent. It replaces hand-rolled `curl` against the HTTP API.
+
+Its `--help` is generated from the command surface, so it cannot drift from the
+binary you have installed. When this page and `tdt --help` disagree, believe
+`--help`.
+
+## Install
+
+```bash
+uv tool install ./services/cli      # or: pipx install ./services/cli
+tdt --version
+```
+
+## Point it at a deployment
+
+A **profile** bundles the two things every request needs — the API base URL and
+the business-unit slug — so they stop being environment variables you re-export
+in every shell.
+
+```bash
+tdt profile add prod --url https://tdt.example.com --bu platform --default
+tdt login
+tdt whoami
+```
+
+Config lives in `~/.config/tdt/config.toml`; credentials in
+`~/.config/tdt/credentials.json`, created `0600`.
+
+### Signing in
+
+`tdt login` asks the server which providers are enabled (`GET /auth/config`) and
+picks for you:
+
+| Flag | When |
+|---|---|
+| `--sso` | OIDC is configured. Opens a browser; the loopback flow hands the token pair back. Default when available. |
+| `--password` | No OIDC. Prompts for email and password. |
+| `--api-key` | CI and other unattended callers. Paste a `tdt_…` key minted in the UI. |
+
+The first two store a refresh token and **renew themselves**, so signing in is a
+once-per-machine step rather than a daily one. API keys have nothing to refresh:
+they are long-lived by design, and they force their own business unit, so `--bu`
+is ignored for them.
+
+!!! note "`--sso` needs a browser on the same machine"
+    The flow binds a listener on `127.0.0.1`, so over SSH the callback has
+    nowhere to land. Use `--api-key` there. If the deployment predates the
+    loopback hand-off the CLI says so immediately rather than hanging.
+
+## The core loop
+
+```bash
+tdt run plan    my-workspace                     # ends at `planned`, no approval
+tdt run apply   my-workspace                     # shows the diff, prompts you
+tdt run apply   my-workspace -b feat/my-branch   # pin a ref first (pre-merge)
+tdt run destroy my-workspace                     # real terraform destroy
+```
+
+Workspaces are addressable by **name or id**. An ambiguous name is an error,
+never a silent pick.
+
+### Approval gates
+
+This is the reason the CLI exists. Unattended, the safety check belongs in a
+flag rather than in whoever is watching:
+
+```bash
+tdt run apply my-workspace --auto-approve --max-destroy 0
+tdt run apply my-workspace --auto-approve --require-noop     # expect 0/0/0/0
+```
+
+Gates are evaluated on **every** run that reaches `awaiting_approval`, whether
+or not `--auto-approve` was passed, and a violated gate **rejects** the run —
+nothing is applied. Available gates: `--require-noop`, `--max-add`,
+`--max-change`, `--max-destroy`, `--max-replace`.
+
+Without `--auto-approve` and without a TTY, the command exits `4` rather than
+hanging on a prompt nobody can see.
+
+!!! warning "`tdt run destroy` is the only command that deletes infrastructure"
+    `tdt ws delete` merely drops Terraducktel's tracking row and leaves the
+    resources and the state file intact. On a TTY, `destroy` makes you type the
+    workspace name; in automation it requires `--yes`, and should be paired
+    with `--max-destroy N` so an unexpectedly large teardown is refused.
+
+## Reading state
+
+```bash
+tdt context -o json                    # whole-BU snapshot in one call
+tdt ws list                            # add -o json for ids
+tdt ws list -t team=payments           # filter by tag; repeatable and AND-ed
+tdt ws get my-workspace
+tdt run list -w my-workspace --status failed -n 5
+tdt run steps <run-id> --logs          # step timeline, with output
+tdt run graph <run-id>                 # the +/~/-/± diff and changed addresses
+tdt run watch <run-id>                 # follow an in-flight run
+tdt drift summary
+tdt show bus | tdt show accounts | tdt show clusters
+```
+
+`-o json` works on every command and returns the API payload untouched — prefer
+it when parsing. `tdt context` is built for agents and scripts: it replaces four
+or five separate calls with one snapshot of workspaces, recent runs and drift.
+
+## Tags
+
+```bash
+tdt ws tag my-workspace -s team=payments -s tier=prod   # merges
+tdt ws tag my-workspace -u tier                         # remove a key
+tdt ws tag ws-a ws-b ws-c -s owner=platform             # batch
+tdt ws tags                                             # every key, with counts
+```
+
+`--set` merges per key, so retagging a batch's `team` never wipes an `owner` tag
+one of them carries. A batch is all-or-nothing: if any workspace is outside your
+business unit the whole request is rejected, so you are never left guessing which
+half applied. Keys are lowercased by the API; values keep their case.
+
+## Exit codes
+
+Branch on these rather than parsing output. They are a stable contract.
+
+| Code | Meaning |
+|---|---|
+| `0` | success |
+| `1` | usage or configuration error |
+| `2` | authentication — run `tdt login` |
+| `3` | plan phase failed (terraform, checkov, OPA) |
+| `4` | rejected: by you, or by a `--max-*` / `--require-noop` gate |
+| `5` | apply phase failed |
+| `6` | timed out waiting (the run continues server-side) |
+| `7` | API error (404/409/5xx, transport) |
+
+On `3` and `5` the CLI prints the failed step and the tail of its log.
+
+A `403` is **not** an auth-recovery case: it means the credential's role,
+business unit or API-key capability doesn't cover the call. Logging in again
+will not help.
+
+## Global options
+
+`--profile/-p`, `--url`, `--bu` and `-o/--output` may appear either before or
+after the command — `tdt whoami --url …` and `tdt --url … whoami` are the same.
+The exception is a subcommand that declares the same name itself, such as
+`tdt profile add --url`, which keeps its own.
+
+## Using it from an agent
+
+The CLI ships a Claude skill. Inside a clone of this repository it is already
+active at `.claude/skills/tdt/`; elsewhere:
+
+```bash
+tdt skill install     # → ~/.claude/skills/tdt/
+```
+
+An agent driving `tdt` gets the approval gates for free, which is the point: with
+`--max-destroy 0`, "review the diff before approving" stops being an instruction
+that can be skipped and becomes a check that runs.
+
+## Gotchas
+
+- **The executor has no `aws` CLI.** A helm/kubernetes provider using exec-auth
+  (`aws eks get-token`) fails with `executable aws not found`; use SDK token auth
+  (`data.aws_eks_cluster_auth`).
+- **The executor reaches public cloud APIs but not private VPC endpoints**
+  without a network path. Symptom: `dial tcp …:443: i/o timeout` at apply.
+- **A connection failure is usually the network**, not auth — many deployments
+  put the API behind an internal load balancer. The CLI says so explicitly.
+- **Terraducktel imports, it does not scaffold.** A workspace needs its repo
+  directory to exist already; `tdt ws discover --repo <url>` lists importable
+  leaves.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,57 @@
+# Terraducktel
+
+Self-hosted Terraform and Helm orchestration with a human approval gate.
+
+Terraducktel imports modules from a Git repository and runs them through a
+consistent, audited pipeline — `plan → policy scan → cost estimate → human
+approval → apply` — against your own cloud accounts. It runs on Docker Compose,
+costs nothing to license, and depends on no SaaS.
+
+[Back to the project site](../){ .md-button }
+[Source on GitHub](https://github.com/mormor83/terraducktel){ .md-button }
+
+## Where to start
+
+<div class="grid cards" markdown>
+
+-   **[Getting started](ONBOARDING.md)**
+
+    Stand up a local stack, connect a Git repository, import your first
+    workspace and take it through a run.
+
+-   **[The `tdt` CLI](CLI.md)**
+
+    Drive workspaces and runs from a terminal, CI, or an AI agent — with
+    approval gates you can enforce rather than remember.
+
+-   **[Architecture](ARCHITECTURE.md)**
+
+    Services, the run lifecycle, state handling, multi-tenancy and where the
+    trust boundaries sit.
+
+-   **[API reference](API.md)**
+
+    Every HTTP endpoint, with auth, scoping and payloads.
+
+</div>
+
+## The idea
+
+Most Terraform automation makes one of two trades: run everything by hand and
+accept that it drifts and nobody can audit it, or fully automate and accept that
+a bad plan applies itself at 3am.
+
+Terraducktel keeps the pipeline automated and the *decision* manual. Every apply
+stops at an approval gate showing exactly what will change. What differs from a
+CI job that pauses is that the pause is a first-class object: it has a diff, a
+policy result, a cost estimate, an audit trail, and an operator who owns it.
+
+The [CLI](CLI.md) extends that to unattended callers by turning the review into
+a condition — `--max-destroy 0` refuses a plan that would delete anything,
+rather than trusting whoever is watching to notice.
+
+## Operations
+
+- [Disaster recovery runbook](RUNBOOK-disaster-recovery.md)
+- [Security policy](https://github.com/mormor83/terraducktel/blob/main/SECURITY.md)
+- [Contributing](https://github.com/mormor83/terraducktel/blob/main/CONTRIBUTING.md)

--- a/docs/stylesheets/brand.css
+++ b/docs/stylesheets/brand.css
@@ -1,0 +1,33 @@
+/* Terraducktel palette, lifted from docs/branding/td/tokens/tokens.json so the
+   docs and the landing page are demonstrably the same colours rather than
+   approximately the same colours. */
+:root {
+  --td-brand-300: #56aaa3;
+  --td-brand-400: #2f8a85;
+  --td-brand-500: #1f6f6c;
+  --td-brand-700: #134847;
+  --td-accent-400: #5eb85a;
+}
+
+[data-md-color-primary="custom"] {
+  --md-primary-fg-color: var(--td-brand-500);
+  --md-primary-fg-color--light: var(--td-brand-400);
+  --md-primary-fg-color--dark: var(--td-brand-700);
+}
+
+[data-md-color-accent="custom"] {
+  --md-accent-fg-color: var(--td-brand-400);
+}
+
+/* In dark mode the 500 is too low-contrast against the slate surface for link
+   text, so links move up two steps. Material's own slate scheme does the same
+   for its defaults. */
+[data-md-color-scheme="slate"] {
+  --md-primary-fg-color: var(--td-brand-700);
+  --md-accent-fg-color: var(--td-brand-300);
+  --md-typeset-a-color: var(--td-brand-300);
+}
+
+[data-md-color-scheme="default"] {
+  --md-typeset-a-color: var(--td-brand-500);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,101 @@
+# Docs site for https://mormor83.github.io/terraducktel/docs/
+#
+# The landing page is a hand-built index.html living at the root of the
+# gh-pages branch. This builds into `docs/` *underneath* it, so the two
+# coexist: `/` stays the marketing page, `/docs/` is the reference. The deploy
+# job in .github/workflows/ci-cd.yml only ever replaces the `docs/` subtree —
+# `mkdocs gh-deploy` is deliberately NOT used, because it wipes the branch.
+
+site_name: Terraducktel
+site_description: Self-hosted Terraform & Helm orchestration with a human approval gate.
+site_url: https://mormor83.github.io/terraducktel/docs/
+repo_url: https://github.com/mormor83/terraducktel
+repo_name: mormor83/terraducktel
+edit_uri: edit/main/docs/
+
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  logo: branding/td/brand/terraducktel-mark.svg
+  favicon: branding/td/brand/favicon.svg
+  font:
+    # Matches the landing page so moving between them doesn't feel like two
+    # different products.
+    text: Inter
+    code: JetBrains Mono
+  features:
+    - navigation.sections
+    - navigation.top
+    - navigation.tracking
+    - content.code.copy
+    - content.action.edit
+    - search.highlight
+    - search.suggest
+    - toc.follow
+  palette:
+    # Follows the OS by default, with an explicit toggle — the same three-state
+    # behaviour the app itself has.
+    - media: "(prefers-color-scheme)"
+      # `primary`/`accent` must be repeated here, not only on the light and dark
+      # entries: the auto entry is the one Material renders first, and without
+      # them it stamps data-md-color-primary="indigo" and the brand palette
+      # never loads for anyone on the default (system) setting — i.e. most
+      # visitors.
+      primary: custom
+      accent: custom
+      toggle: { icon: material/brightness-auto, name: Follow system }
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: custom
+      accent: custom
+      toggle: { icon: material/brightness-7, name: Switch to dark }
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: custom
+      accent: custom
+      toggle: { icon: material/brightness-4, name: Switch to light }
+
+extra_css:
+  - stylesheets/brand.css
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+
+plugins:
+  - search
+
+nav:
+  - Overview: index.md
+  - Getting started: ONBOARDING.md
+  - CLI (tdt): CLI.md
+  - Architecture: ARCHITECTURE.md
+  - API reference: API.md
+  - Operations:
+      - Disaster recovery: RUNBOOK-disaster-recovery.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/mormor83/terraducktel
+
+# `docs/branding/**` is image and token assets, not pages. They still need to
+# ship (the theme logo points into them), so they are copied but kept out of
+# the nav rather than excluded outright.
+not_in_nav: |
+  branding/**


### PR DESCRIPTION
**Live now:** https://mormor83.github.io/terraducktel/docs/ — I published the first build by hand so the pages exist before the nav points at them. This PR adds the config and the CI jobs that rebuild it on every merge.

## Why

The repo carried ~1900 lines of public documentation readable only as raw markdown on GitHub:

| | lines |
|---|---|
| `docs/API.md` | 898 |
| `docs/ARCHITECTURE.md` | 627 |
| `README.md` | 355 |
| `docs/ONBOARDING.md`, `docs/RUNBOOK-disaster-recovery.md` | — |

The site linked to the README and nothing else. And the CLI had **no public docs at all** — the internal `docs/claude/cli.md` isn't published, so OSS had the code and a short `services/cli/README.md`.

## The landing page is untouched

The hand-built `index.html` stays at `/`; docs live at `/docs/`. The publish step **splices** the built site into the `docs/` subtree of gh-pages rather than running `mkdocs gh-deploy`, which replaces the whole branch and would take the landing page with it.

I dry-ran the splice locally before pushing and verified `index.html` came out byte-identical. The only change to it is one added nav link.

`.nojekyll` is set, or Jekyll swallows MkDocs' underscore-prefixed asset dirs.

## New: `docs/CLI.md`

Install, the three sign-in modes and why each exists, the approval gates, the exit-code contract, tags, and the gotchas that actually bite (no `aws` binary in the executor, private VPC endpoints, Terraducktel imports rather than scaffolds).

## CI

| Job | When |
|---|---|
| `docs-build` | on PRs — `mkdocs build --strict` |
| `docs` | on merge to the default branch — builds and publishes |

`--strict` turns a broken internal link or a page missing from the nav into a build failure. That check is the only thing that keeps docs correct as the code moves; without it this rots in a month.

Both are gated behind the test jobs, consistent with the rest of the pipeline. The existing `test_ci_pipeline_gating.py` still passes.

## Fixed along the way

Two anchors that had always been broken — `#runs--apiv1runs…` in API.md and `#5-auth--rbac` in ARCHITECTURE.md. Invisible when GitHub renders the markdown, 404s on a real site, and now caught by `--strict`.

And a palette bug I shipped and had to correct: the `(prefers-color-scheme)` entry carried no `primary`/`accent`, and that's the entry Material renders first — so the page went out with `data-md-color-primary="indigo"` and the brand teal never loaded for anyone on the default system setting. Fixed and re-published; the live site now serves `#1f6f6c`.

## Verified live

```
/                                      200
/docs/                                 200
/docs/CLI/                             200
/docs/API/                             200
/docs/ARCHITECTURE/                    200
/docs/ONBOARDING/                      200
/docs/search/search_index.json         200   (108 sections indexed)
data-md-color-primary="custom"  ·  brand.css serves #1f6f6c
```

## Not done

`API.md` and `ARCHITECTURE.md` predate the CLI, `/auth/refresh`, tags and key rotation, so parts are likely stale. Publishing them makes that more visible, not less — worth a content review pass as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)