### PR TITLE
docs: review pass — reconcile API.md and ARCHITECTURE.md with the code

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -56,8 +56,9 @@ config key (`local` / `oidc` / `both`).
 | Method | Path | Description | Auth |
 |---|---|---|---|
 | POST | `/auth/token` | Local email+password login. Returns access + refresh tokens. | public |
-| GET  | `/auth/config` | Public auth config: `{mode, oidc_enabled, oidc_issuer}`. | public |
-| GET  | `/auth/oidc/login` | Begin OIDC login redirect for the configured provider. 404 if OIDC isn't enabled; 503 if enabled but not configured. | public |
+| POST | `/auth/refresh` | Redeem a refresh token for a fresh access+refresh pair. Rejects access tokens, run-scoped executor tokens and `tdt_` API keys. | public (bearer not required — the body carries the token) |
+| GET  | `/auth/config` | Public auth config: `{mode, oidc_enabled, oidc_issuer, cli_loopback}`. | public |
+| GET  | `/auth/oidc/login` | Begin OIDC login redirect for the configured provider. 404 if OIDC isn't enabled; 503 if enabled but not configured. Optional `cli_port` + `cli_nonce` query params switch the callback to the CLI loopback hand-off (see below). | public |
 | GET  | `/auth/oidc/callback` | OIDC callback target — exchanges the auth code for tokens, upserts the local user, redirects the browser to `/auth/oidc-finish?access_token=…&refresh_token=…`. | public |
 
 **POST /auth/token** body `{"email": "...", "password": "..."}` →
@@ -69,6 +70,29 @@ configurable claim (default group/role claim) and maps it to a TDT role +
 `is_superadmin`; see `services/api/app/auth/oidc.py` for the config-key contract.
 
 ---
+
+**POST /auth/refresh** body `{"refresh_token": "..."}` → a new
+`{access_token, refresh_token, token_type}`.
+
+Both `/auth/token` and the OIDC callback have always *minted* a refresh token;
+this is what redeems one. A new refresh token comes back each time, so an
+actively-used client slides forward indefinitely and never re-authenticates.
+
+Tokens are stateless — there is no server-side revocation list — so a leaked
+refresh token stays usable until it expires
+(`auth.refresh_token_expire_hours`, default 24). Keep that TTL short, and
+revoke access by deleting the user. Claims are re-read from the user row on
+every refresh, so a demotion takes effect on the next one rather than
+persisting for the life of the token.
+
+**CLI loopback sign-in.** `GET /auth/oidc/login?cli_port=<1024-65535>&cli_nonce=<16-128 url-safe chars>`
+makes the callback hand the token pair to a listener on `http://127.0.0.1:<cli_port>/callback`
+instead of redirecting to the SPA. The IdP's registered `redirect_uri` is
+unchanged — it still points at this API's own callback — and `cli_port` travels
+in the signed session cookie rather than the callback URL, so a crafted callback
+cannot retarget the hand-off. The redirect host is hardcoded to `127.0.0.1`.
+`GET /auth/config` advertises `cli_loopback: true` so a client can tell whether
+a deployment supports this before trying.
 
 ## Users — `/api/v1/users`
 
@@ -117,6 +141,7 @@ router — an API key can never mint, rotate, or revoke API keys, even at the
 | GET | `/api-keys` | List keys in the current BU (masked — `token_prefix`, never the token). | admin |
 | POST | `/api-keys` | Mint a key. Returns the plaintext `token` **once**. | admin |
 | POST | `/api-keys/{id}/regenerate` | Rotate an active key's secret in place, keeping name/capability/allowlist/expiry. Returns the new plaintext `token` **once**. | admin |
+| POST | `/api-keys/{id}/rotate` | Mint a **successor** key and keep the old secret usable for an overlap window. Returns the new plaintext `token` **once**, plus `predecessor_id` and `predecessor_expires_at`. | admin |
 | DELETE | `/api-keys/{id}` | Soft-revoke a key (immediate 401 for further use). Idempotent. | admin |
 
 **POST /api-keys** body:
@@ -139,6 +164,46 @@ workspace allowlist, expiry) unchanged. The old token stops working
 immediately. Rejects with **409** if the key is already revoked or has
 already expired — rotation only ever refreshes a *live* secret; create a new
 key instead of trying to revive a dead one.
+
+**POST /api-keys/{id}/rotate** body `{"overlap_hours": 24}` (0–168, default 24)
+— the option to reach for when more than one consumer holds the key.
+
+`regenerate` swaps a secret in place and the old one dies that instant, which
+is fine for a single consumer and unusable when the same key sits in a CI
+secret store, a laptop keychain and a cron job: those cannot be updated
+atomically. Rotation creates a **second key** so both secrets work at once, and
+you move consumers over one at a time.
+
+Two rows are involved, because an overlap needs two usable secrets and
+`token_hash` is unique per row:
+
+| | |
+|---|---|
+| old key | `expires_at` pulled in to `now + overlap_hours`, `rotated_at` set, `superseded_by_id` → the successor. Nothing else changes, so it keeps authenticating until the window closes. |
+| new key | same name, capability, workspace allowlist, owner and BU; fresh secret, clean `last_used_at`. |
+
+```jsonc
+{ ...successorKey,
+  "token": "tdt_…",                                  // once, as on create
+  "predecessor_id": "…",
+  "predecessor_expires_at": "2026-09-02T14:45:01Z" } // deadline for the swap
+```
+
+The window rides the ordinary `expires_at` check, so the old key stops on its
+own — there is nothing to call afterwards and no cleanup job. `overlap_hours: 0`
+is an immediate cutover.
+
+Constraints:
+
+- A rotation **never extends** a credential's life. If the old key already
+  expires sooner than the requested window, the earlier deadline wins.
+- A key can be rotated **once**. Chaining would leave several live secrets
+  behind one name; **409** names the successor to rotate instead.
+- Revoked or expired keys are refused with **409**, as with `regenerate`.
+
+`rotated_at` and `superseded_by_id` appear on every key in `GET /api-keys`, so a
+client can tell "expiring because an admin said so" from "retiring because it
+was rotated".
 
 **DELETE /api-keys/{id}** — sets `revoked_at`; calling it again on an
 already-revoked key is a no-op 200 (idempotent), not a 404/409.
@@ -334,9 +399,17 @@ state is stored. `azureblob` requires a linked `azure_subscription_id` whose
 `gcp_project_id` links the workspace to a GCP project (google provider), the
 mirror of `azure_subscription_id`.
 
+`tags` is a free-form key/value map (`{"team": "payments", "tier": "prod"}`).
+Keys are lowercased on write — `Team` and `team` are the same tag — while values
+keep their case. A workspace carries at most 32; keys are 1–64 chars matching
+`[a-z0-9][a-z0-9._-]*[a-z0-9]`, values up to 255. Responses always return an
+object, never `null`.
+
 | Method | Path | Description | Min role | BU |
 |---|---|---|---|---|
-| GET | `/workspaces` | List workspaces. | viewer | BU-scoped |
+| GET | `/workspaces` | List workspaces. `?tag=team=payments` filters by tag — repeatable and AND-ed; a bare `?tag=owner` matches any value. | viewer | BU-scoped |
+| GET | `/workspaces/tags` | Every tag key in the BU with its values and usage counts. | viewer | BU-scoped |
+| POST | `/workspaces/tags` | Bulk set/unset tags across many workspaces. | operator | BU-scoped |
 | GET | `/workspaces/{id}` | Get a single workspace. | viewer | BU-scoped |
 | POST | `/workspaces` | Create a workspace (manual). | admin | BU-scoped |
 | PUT | `/workspaces/{id}` | Update workspace (branch override, drift settings, `state_aws_account_id`, `azure_subscription_id`, `gcp_project_id`, `state_backend`, …). | admin-tier key or interactive operator+ | BU-scoped |
@@ -458,6 +531,41 @@ a second concurrent run race state.
 
 ---
 
+
+### POST /workspaces/tags — body
+
+```jsonc
+{
+  "workspace_ids": ["<ws-id>", "<ws-id>"],
+  "set":   { "team": "payments", "tier": "prod" },  // merged per key
+  "unset": ["deprecated"]                           // removed if present
+}
+```
+
+→ `{ "updated": 2, "workspaces": [ …full workspace objects… ] }`
+
+`set` **merges** rather than replacing the map, so retagging twenty workspaces'
+`team` cannot wipe the `owner` tag one of them happens to carry. To replace a
+single workspace's tags wholesale, `PUT /workspaces/{id}` with a `tags` object.
+
+The batch is **all-or-nothing**: any id outside the current BU fails the whole
+request with 404 rather than tagging a subset, because a partially-applied bulk
+edit leaves you unable to tell which half landed. 400 if neither `set` nor
+`unset` is given, or if a key or value fails validation.
+
+Each affected workspace gets its own `AuditLog` row (`workspace.tags_bulk_edit`),
+so "what happened to workspace X?" stays answerable.
+
+### GET /workspaces/tags
+
+```jsonc
+[ { "key": "team", "count": 3,
+    "values": [ {"value": "payments", "count": 2}, {"value": "ops", "count": 1} ] } ]
+```
+
+Keys sorted alphabetically, values by descending usage. Feeds filter
+autocomplete, and makes it obvious when two keys have drifted apart.
+
 ## Workspace variables — `/api/v1/workspaces/{id}/variables`
 
 | Method | Path | Description | Min role |
@@ -501,7 +609,7 @@ per key).
 | Method | Path | Description | Min role |
 |---|---|---|---|
 | POST | `/workspaces/{id}/runs` | Trigger a run (plan/apply/destroy). | operator (+ `plan` or `apply` API-key tier) |
-| GET | `/runs` | List runs (BU-scoped; API-key callers additionally narrowed to their workspace allowlist). | viewer |
+| GET | `/runs` | List runs, newest first (BU-scoped; API-key callers additionally narrowed to their workspace allowlist). Filters: `?workspace_id=`, `?status=` (comma-separated, e.g. `failed,cancelled`; an unknown value is a **400** listing the valid ones), `?limit=` (1–1000). No default cap — the UI fetches the full list and buckets it client-side. | viewer |
 | GET | `/runs/{run_id}` | Get a run. | viewer |
 | PATCH | `/runs/{run_id}` | Executor callbacks — status, plan output, plan_json, tfplan_b64, policy_status. Triggers notifications + auto-approve gate on `awaiting_approval`. | operator |
 | POST | `/runs/{run_id}/heartbeat` | Executor liveness ping (run_jobs.heartbeat_at). 204, or 404 if there's no picked job for this run. | operator |
@@ -509,7 +617,7 @@ per key).
 | GET | `/runs/{run_id}/plan` | Raw plan output: `{plan_output}`. | viewer (+ `read` API-key tier) |
 | GET | `/runs/{run_id}/tfplan` | Base64-encoded `tfplan` binary (executor uses this on apply): `{tfplan_b64}`. | operator |
 | GET | `/runs/{run_id}/graph` | Structured `{nodes, edges, summary}` parsed from plan_json. | viewer (+ `read` API-key tier) |
-| GET | `/runs/{run_id}/steps` | Run timeline (Init / Checkov / Plan / etc). | viewer (+ `read` API-key tier) |
+| GET | `/runs/{run_id}/steps` | Run timeline (Init / Checkov / Plan / etc). `?since=<position>` returns only steps at or after that index, and `?include_output=false` omits each step's log blob — together they make polling a long apply cheap, since the finished prefix carries the bulk of the bytes. | viewer (+ `read` API-key tier) |
 | PATCH | `/runs/{run_id}/steps/{step_id}` | Executor callback to update a single step. | operator |
 | GET | `/runs/{run_id}/policies` | OPA policy bundle + gate config the executor should enforce for this run. BU is derived from the run's workspace. | operator |
 
@@ -541,7 +649,7 @@ guardrails enforced by `PATCH /runs/{run_id}`:
   a reconnecting executor retry a heartbeat-adjacent status write safely).
 - Cancellable source states: `pending`, `running`, `planning`, `planned`,
   `awaiting_approval`. Once `applying`, a run must complete or fail — it can
-  no longer be cancelled (409 on `POST /cancel`).
+  no longer be cancelled (409 on `POST /runs/{run_id}/cancel`).
 
 ### Auto-approve flow
 
@@ -875,6 +983,20 @@ is `pg_try_advisory_lock`-based, not DynamoDB.
 
 ---
 
+## Operational endpoints (unversioned, no auth)
+
+These sit outside `/api/v1` and are for probes and scrapers, not clients.
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/health` | Liveness/readiness probe. Used by the compose healthcheck and the ECS target group. |
+| GET | `/metrics` | Prometheus text-format counters (request counts and latency sums). |
+| GET | `/server-info` | Build/version identification. |
+
+They are deliberately unauthenticated so a load balancer can reach them before
+any credential exists. Do not expose `/metrics` publicly without a proxy in
+front of it.
+
 ## Status codes used everywhere
 
 - `200 / 201 / 204` — success.
@@ -891,8 +1013,12 @@ is `pg_try_advisory_lock`-based, not DynamoDB.
 ## Audit actions you'll see
 
 `login`, `workspace.create`, `workspace.update`, `workspace.delete`,
-`workspace.force_delete`, `workspace.force_unlock`, `auto_delete_orphan`,
-`run.trigger`, `approve`, `auto_approve`, `auto_apply_skipped`, `reject`,
-`aws_account.create`, `aws_account.update`, `integration.github.set`,
-`integration.slack.set`, `api_key.create`, `api_key.regenerate`,
-`api_key.revoke`, …
+`workspace.force_delete`, `workspace.force_unlock`, `workspace.tags_bulk_edit`,
+`auto_delete_orphan`, `run.trigger`, `approve`, `auto_approve`,
+`auto_apply_skipped`, `reject`, `aws_account.create`, `aws_account.update`,
+`integration.github.set`, `integration.slack.set`, `api_key.create`,
+`api_key.regenerate`, `api_key.rotate`, `api_key.revoke`, …
+
+`workspace.tags_bulk_edit` writes **one row per affected workspace** rather than
+one per batch, so a workspace's own audit trail shows every tag change that ever
+touched it.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,6 +32,11 @@ is the single source of truth for both metadata and locking.
 
 ---
 
+Three clients speak the same HTTP API with no privileged back door between
+them: the React UI, the `tdt` CLI (terminals, CI, and AI agents — see
+[CLI](CLI.md)), and the executor, which is confined to run-scoped callback
+routes by a token type that cannot authenticate anywhere else.
+
 ## 2. Service topology
 
 ```
@@ -40,6 +45,7 @@ is the single source of truth for both metadata and locking.
                               └──────────────────┬───────────────────────┘
                                                   │
  browser ──────────────────► ui (nginx, :3001) ───┤
+ tdt CLI / CI / agent ────────────────────────────┤  (same HTTP API, no privileged path)
                                                   │
                                                   ▼
                                          api (FastAPI, :8001)
@@ -117,7 +123,7 @@ forward-only (`services/api/alembic/versions/NNN_*.py`).
 
 | Model | Table | What |
 |---|---|---|
-| `Workspace` | `workspaces` | One Terraform leaf module or one Helm chart. Canonical identity is `(business_unit_id, aws_account_id, region, environment, tf_working_dir)`. Carries `repo_url`/`repo_ref` (Git source), `kind` (`terraform` default or `helm`), `cluster_id` (helm target), `azure_subscription_id` / `gcp_project_id` (optional Azure/GCP targets), `state_backend` (`s3` default \| `azureblob` \| `gcs`), `drift_status`, `path_status` (`ok`/`orphaned`/`unknown` — tracks whether the leaf still exists at `repo_ref`), `webhook_enabled`. |
+| `Workspace` | `workspaces` | One Terraform leaf module or one Helm chart. Canonical identity is `(business_unit_id, aws_account_id, region, environment, tf_working_dir)`. Carries `repo_url`/`repo_ref` (Git source), `kind` (`terraform` default or `helm`), `cluster_id` (helm target), `azure_subscription_id` / `gcp_project_id` (optional Azure/GCP targets), `state_backend` (`s3` default \| `azureblob` \| `gcs`), `drift_status`, `path_status` (`ok`/`orphaned`/`unknown` — tracks whether the leaf still exists at `repo_ref`), `webhook_enabled`, `tags` (free-form key/value JSON; keys lowercased on write). Tags are a JSON column rather than a join table — at this fleet size a dict scan matches what an index would give, and it keeps tags atomic with the row so there is no orphan cleanup on delete. |
 | `Run` | `runs` | One plan/apply/destroy execution. FSM `status` (see [§4](#4-the-run-fsm)), captured `branch`, `plan_output`/`plan_json`, base64 `tfplan_b64` (the exact binary re-applied post-approval), encrypted `variables_encrypted` (per-run TF_VAR overrides), `policy_status`, `auto_approve_if_no_changes`/`auto_approve_skip_apply`. |
 | `RunStep` | `run_steps` | Per-step timeline row (Git Clone → Checkov → Plan → OPA → Cost → Awaiting Approval → Apply → …), kind-aware (Terraform vs. Helm step lists live in `run_step.py`). |
 | `RunArtifact` | `run_artifacts` | Blob output attached to a run (plan output, logs, checkov report). |
@@ -240,6 +246,14 @@ configurable JSON mapping, re-evaluated on every sign-in. Tested against a
 generic OIDC IdP — see `services/api/app/auth/oidc.py` for the group-mapping
 implementation.
 
+The same flow serves the CLI. `GET /auth/oidc/login?cli_port=&cli_nonce=`
+records the loopback port in the signed session cookie; the callback then hands
+the token pair to `http://127.0.0.1:<port>/callback` instead of the SPA. The
+IdP's registered `redirect_uri` never changes, and because the port rides the
+cookie rather than the URL, a crafted callback cannot retarget the hand-off —
+the host is hardcoded. `GET /auth/config` advertises `cli_loopback` so a client
+can detect support instead of hanging on a deployment that lacks it.
+
 ### Role hierarchy
 
 `viewer(0) < operator(1) < admin(2)`, defined in
@@ -302,8 +316,19 @@ mint/revoke keys, manage users, or create/update BUs. Those surfaces gate on
 the *owner's* `is_superadmin`, which an `admin` key would otherwise inherit
 as a privilege escalation if this guard didn't exist.
 
+**Rotation.** `POST /api-keys/{id}/regenerate` replaces a key's secret in place
+and the old one dies immediately — correct when a single consumer holds it.
+`POST /api-keys/{id}/rotate` instead mints a *successor* row and pulls the old
+key's `expires_at` in to `now + overlap_hours` (default 24, max 168), so both
+secrets authenticate during the window and consumers can be migrated one at a
+time. The overlap is enforced by the ordinary `expires_at` check in
+`api_key_service.is_active()` — no second auth path and no sweeper job. A
+rotation never *extends* a shorter expiry, and a key can only be rotated once
+(rotate its successor after that), so several live secrets can never hide behind
+one name. `rotated_at` and `superseded_by_id` record the link.
+
 Management: `POST/GET/DELETE /api/v1/api-keys`, `admin`-only, every
-create/revoke written to `AuditLog`. UI: Settings → **API keys** tab
+create/revoke/rotate written to `AuditLog`. UI: Settings → **API keys** tab
 (admin-only). Full detail in `docs/API.md` and `app/auth/rbac.py`.
 
 ---
@@ -615,6 +640,7 @@ Where to look when adding something new:
 | Adding... | Start here |
 |---|---|
 | A new API endpoint / resource type | `app/schemas/<domain>.py` → `app/services/<domain>_service.py` → `app/routers/<domain>.py` (thin, `require_role`-gated) → `tests/test_<domain>.py` → update `docs/API.md`. |
+| A new CLI command | `services/cli/tdt/commands/<group>_cmd.py`, then **add the endpoint to `services/cli/api_contract.json`** — two tests read that file to keep the CLI and the API from drifting apart, and one of them fails on an undeclared call. Update `docs/CLI.md` and the two copies of `SKILL.md` (a test enforces they stay identical). |
 | A new encrypted credential type | Copy the Fernet/HKDF pattern in `aws_account_service.py` / `cluster_service.py` — **derive a new domain-specific HKDF salt**, don't reuse an existing one or roll a new encryption scheme. See [§6](#6-encryption-model). |
 | A new cloud provider target (beyond AWS/Azure/K8s) | Model it like `AzureSubscription`/`K8sCluster`: its own table, its own encrypted-credential service, a `workspace.<provider>_id` FK, and executor_service branching analogous to the `kind=helm` path in `executor_service.py`. |
 | A new run step (scanner, gate, reporter) | `run_step.py`'s `DEFAULT_STEP_NAMES`/`HELM_STEP_NAMES` lists (order matters — it's display order) + the matching block in `services/executor/entrypoint.sh`, wired through `executor_service.py`'s env dict if it needs config. |

--- a/services/api/tests/test_api_docs_coverage.py
+++ b/services/api/tests/test_api_docs_coverage.py
@@ -1,0 +1,87 @@
+"""`docs/API.md` must document every endpoint the API actually serves.
+
+The reference drifted quietly: by the time anyone looked, `POST /auth/refresh`,
+`POST /api-keys/{id}/rotate`, both `/workspaces/tags` routes and the query
+params on `GET /runs` and `/runs/{id}/steps` were all live and undocumented,
+while the doc still read as if they didn't exist. Nothing failed, because prose
+has no tests — the same failure mode `api_contract.json` guards for the CLI.
+
+This closes it from the other side: the OpenAPI schema is generated from the
+routers, so it cannot lie about what exists.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+API_MD = Path(__file__).resolve().parents[3] / "docs" / "API.md"
+
+# `/internal/*` is included on both sides: those routes are state-token-guarded
+# rather than client-facing, but API.md documents them, so the reference should
+# stay honest about them too.
+
+# Section headings carry the shared prefix, so rows below them use a `…`
+# shorthand for it. Resolve those by hand rather than teaching the parser to
+# track headings.
+SHORTHAND = {
+    ("GET", "/workspaces/{}/variables"),
+    ("POST", "/workspaces/{}/variables"),
+    ("PATCH", "/workspaces/{}/variables/{}"),
+    ("DELETE", "/workspaces/{}/variables/{}"),
+}
+
+
+def _norm(path: str) -> str:
+    return re.sub(r"\{[^}]*\}", "{}", path.replace("/api/v1", "").rstrip("/")) or "/"
+
+
+@pytest.fixture(scope="module")
+def live() -> set[tuple[str, str]]:
+    from app.main import app
+
+    out = set()
+    for path, ops in app.openapi()["paths"].items():
+        norm = _norm(path)
+        for method in ops:
+            if method in ("get", "post", "put", "patch", "delete"):
+                out.add((method.upper(), norm))
+    return out
+
+
+@pytest.fixture(scope="module")
+def documented() -> set[tuple[str, str]]:
+    assert API_MD.exists(), f"API reference missing at {API_MD}"
+    text = API_MD.read_text()
+    found = set()
+    # `| GET | `/path` | …` table rows
+    for m, p in re.findall(r"^\|\s*(GET|POST|PUT|PATCH|DELETE)\s*\|\s*`([^`]+)`", text, re.M):
+        found.add((m, _norm(p)))
+    # `### POST /workspaces/import` headings and `**POST /auth/token**` prose
+    for m, p in re.findall(r"(GET|POST|PUT|PATCH|DELETE)\s+`?(/[A-Za-z0-9_\-{}/.]+)", text):
+        found.add((m, _norm(p)))
+    return found | SHORTHAND
+
+
+def test_the_parser_found_something(documented):
+    """A silent zero here would make the real assertion vacuous."""
+    assert len(documented) > 100, f"only parsed {len(documented)} endpoints from API.md"
+
+
+def test_every_endpoint_is_documented(live, documented):
+    missing = sorted(live - documented)
+    assert not missing, (
+        "These endpoints exist but are absent from docs/API.md:\n  "
+        + "\n  ".join(f"{m} {p}" for m, p in missing)
+    )
+
+
+def test_no_endpoint_is_documented_that_no_longer_exists(live, documented):
+    """Catches a route renamed or removed without the reference following."""
+    # Judge only paths the doc spells out in full. Rows under a section heading
+    # use a `…` prefix for the shared path; those are resolved by SHORTHAND.
+    concrete = {(m, p) for m, p in documented if "…" not in p}
+    stale = sorted(concrete - live - SHORTHAND)
+    assert not stale, (
+        "docs/API.md documents endpoints the API no longer serves:\n  "
+        + "\n  ".join(f"{m} {p}" for m, p in stale)
+    )


### PR DESCRIPTION
The follow-up flagged in #17. Publishing the reference made its gaps legible.

## Method

Rather than reading for staleness, I diffed every documented endpoint against the **generated OpenAPI schema** — it comes from the routers, so it can't lie about what exists.

Result: **135 of 139 documented**, and nothing documented that no longer exists.

## Missing outright

```
POST /auth/refresh
POST /api-keys/{id}/rotate
GET  /workspaces/tags
POST /workspaces/tags
GET  /health, /metrics, /server-info
```

## Parameter-level drift

The interesting half — a route-name check would have missed all of it:

| Endpoint | Was missing |
|---|---|
| `GET /runs` | **no query params documented at all** — `workspace_id`, `status`, `limit` are all live |
| `GET /runs/{id}/steps` | `since`, `include_output` |
| `GET /workspaces` | `?tag=` |
| `GET /auth/oidc/login` | `cli_port`, `cli_nonce` (the CLI loopback hand-off) |
| `GET /auth/config` response | `cli_loopback` |
| API-key responses | `rotated_at`, `superseded_by_id` |

Also added: the `POST /workspaces/tags` body with the merge-vs-replace and all-or-nothing semantics, the `GET /workspaces/tags` index shape, the rotation flow with its two-row explanation and constraints, tag validation rules, and `api_key.rotate` / `workspace.tags_bulk_edit` in the audit-actions list.

## Nothing was stale

Five entries looked stale at first and weren't: four `…/variables` rows use a section-relative shorthand (the heading carries the prefix), and one `POST /cancel` is a prose fragment. I spelled the prose one out in full anyway — a reader could reasonably mistake `POST /cancel` for the actual path.

## ARCHITECTURE.md

- Workspace model gains `tags`, and why it's a JSON column rather than a join table
- §5 gains rotation-with-overlap and the CLI loopback flow
- §1, §2 and §12 now acknowledge **the CLI exists** — it appeared nowhere in a document that describes every client, including a `services/cli/` row in the extension-points table pointing at `api_contract.json`

## The guard

`test_api_docs_coverage.py` stops this recurring. A new endpoint without a doc row fails CI; so does a doc row for a route that's gone. Same idea as `api_contract.json` guarding the CLI, pointed at the reference.

I verified it catches **both** directions, and that the parser finding nothing is itself a failure — otherwise the main assertion would pass vacuously, which is exactly how a guard like this quietly stops working.

Two false positives in my first version were worth fixing rather than suppressing: `/internal/*` was excluded from the live set but not the documented set, and the `…` shorthand filter didn't match.

## Tests

644 API. `mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)