### PR TITLE
fix(ci): fetch gh-pages before splicing the docs site into it

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -227,6 +227,15 @@ jobs:
       contents: write   # push the built site to gh-pages
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The publish step splices into the EXISTING `gh-pages` branch, so
+          # that ref has to be present locally. The default checkout is a
+          # shallow, single-branch clone of the pushed ref only, so
+          # `git worktree add … gh-pages` died with
+          # "fatal: invalid reference: gh-pages" and the site silently stopped
+          # updating. fetch-depth: 0 fetches every branch — and unshallows the
+          # clone, without which the push back to gh-pages is rejected.
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:
@@ -251,7 +260,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           tmp="$(mktemp -d)"
-          git worktree add --quiet "$tmp" gh-pages
+          git worktree add --quiet "$tmp" -B gh-pages origin/gh-pages
 
           rm -rf "$tmp/docs"
           mkdir -p "$tmp/docs"


### PR DESCRIPTION
The docs site has not rebuilt itself once since the publish job was added — **both** pushes to `main` failed at the final step ([33514814217](https://github.com/mormor83/terraducktel/actions/runs/33514814217), [33517099515](https://github.com/mormor83/terraducktel/actions/runs/33517099515)).

## What broke

Every other job passed and `mkdocs build --strict` succeeded, so the run only went red at the very last step:

```
git worktree add --quiet "$tmp" gh-pages
fatal: invalid reference: gh-pages
Process completed with exit code 128
```

`actions/checkout` defaults to a **shallow, single-branch** clone of the pushed ref, so `gh-pages` doesn't exist locally to make a worktree from.

It never showed up on a PR because the job is gated to pushes on the default branch — the PR runs for both #17 and #18 were green.

## User-visible impact

What's live at `/docs/` is still the **hand publish** from before the job existed. The gh-pages tip is `abb6603 docs: apply the brand palette…`, with nothing since.

That means **the PR #18 review pass never reached the site** — the one whose entire purpose was closing documentation gaps. Probing the published API reference:

| | live site | newly built |
|---|---|---|
| `/auth/refresh` | missing | present |
| `/workspaces/tags` | missing | present |
| `cli_loopback` | missing | present |
| `rotated_at` | missing | present |
| `superseded_by` | missing | present |

## The fix

- **`fetch-depth: 0`** on this job's checkout — fetches every branch, *and* unshallows the clone. Both matter: a shallow clone has its push back to `gh-pages` rejected.
- **`git worktree add … -B gh-pages origin/gh-pages`** — build from the remote-tracking ref so the step no longer depends on a local branch of that name existing.

## Verification

Reproduced the runner's exact conditions locally rather than guessing:

- `git clone --depth 1 --branch main --single-branch` → **identical** `fatal: invalid reference: gh-pages`, exit 128.
- Full clone → `worktree add` succeeds, and `git rev-parse --is-shallow-repository` reports `false`, so the push will be accepted.
- Replayed the **whole splice** against the real `gh-pages` branch: produces the expected commit, and the hand-written landing page at the branch root is **untouched** — which is the entire reason this job splices instead of using `mkdocs gh-deploy`.
- Built the real site from `main`: all five previously-missing items are present.

The push itself is the one thing that can't be exercised outside CI. Watching the run on merge.