### PR TITLE
fix(executor): stop dying on step payloads over 128 KB

### DIFF
--- a/services/api/app/services/run_worker.py
+++ b/services/api/app/services/run_worker.py
@@ -307,14 +307,30 @@ async def _reap_stale(session_factory: async_sessionmaker) -> int:
                     run.transition(RunStatus.FAILED)
                 except ValueError:
                     pass
+                # Say only what we actually know: the heartbeat went stale.
+                # The old DONE-branch wording ("executor died before
+                # reporting any step status") was a guess, and a wrong one
+                # whenever the executor had already streamed steps and then
+                # exited mid-run — which is exactly what a crashing executor
+                # looks like. It sent at least one investigation hunting for
+                # a network fault instead of reading the executor's own logs.
                 reason_kind = (
-                    "no heartbeats from worker"
+                    "the worker never finished handing the job to an executor"
                     if job.state == RunJobState.PICKED
-                    else "executor died before reporting any step status"
+                    else (
+                        "the executor stopped sending heartbeats — it exited or "
+                        "was killed; read that run's executor container/task log"
+                    )
                 )
+                last_beat = ""
+                if job.heartbeat_at is not None:
+                    beat = job.heartbeat_at
+                    if beat.tzinfo is None:
+                        beat = beat.replace(tzinfo=timezone.utc)
+                    last_beat = f" (last heartbeat {int((_now() - beat).total_seconds())}s ago)"
                 run.error_output = (
-                    f"Run reaped after {int(stale_after)}s — {reason_kind} "
-                    f"({job.picked_by!r})."
+                    f"Run reaped after {int(stale_after)}s without a heartbeat"
+                    f"{last_beat} — {reason_kind}. Worker: {job.picked_by!r}."
                 )
                 # Best-effort: release the advisory lock on the workspace's
                 # state. The advisory-lock key is the workspace_id hashed to

--- a/services/api/tests/test_executor_step_payload.py
+++ b/services/api/tests/test_executor_step_payload.py
@@ -1,0 +1,362 @@
+"""Regression tests for the executor's step-timeline PATCH payload.
+
+A `terraform plan/apply` log on a real stack is megabytes. The step helper used
+to hand that log to `jq` as a command-line argument (`jq --arg o "$output"`),
+and execve caps a *single* argument at MAX_ARG_STRLEN — 128 KB on Linux,
+regardless of ARG_MAX. Past that, jq never starts:
+
+    /entrypoint.sh: line 121: /usr/bin/jq: Argument list too long
+
+Worse than the lost timeline row: the failure happens inside a shell function,
+and bash skips the ERR trap for failures inside functions unless errtrace
+(`set -E`) is on — it isn't. So `set -e` killed the executor at exit 126 with
+`on_unexpected_err` never firing, nothing was reported, and the run sat in
+`running` until the API reaper failed it `worker.stale_after_seconds` later
+with "executor died before reporting any step status" (see run_worker.py).
+Runs under the limit were unaffected, so this only ever bit big workspaces.
+
+These tests pin the fix: payloads go through files (`--rawfile`), and the
+executor reports its own unexpected death instead of leaving it to the reaper.
+"""
+import os
+import re
+import shutil
+import subprocess
+
+import pytest
+
+ENTRYPOINT = os.path.normpath(
+    os.path.join(os.path.dirname(__file__), "../../executor/entrypoint.sh")
+)
+
+# The kernel's per-argument ceiling (32 pages). The point of the fix is that
+# step output an order of magnitude past this still goes through.
+MAX_ARG_STRLEN = 128 * 1024
+
+
+def entrypoint_source() -> str:
+    with open(ENTRYPOINT) as f:
+        return f.read()
+
+
+def bash_function(name: str) -> str:
+    """Extract one top-level `name() { ... }` block from the entrypoint."""
+    src = entrypoint_source()
+    m = re.search(rf"^{re.escape(name)}\(\) \{{\n(.*?)^\}}$", src, re.S | re.M)
+    assert m, f"{name}() not found in {ENTRYPOINT}"
+    return m.group(0)
+
+
+def code_only(shell: str) -> str:
+    """Drop comment lines — the comments here quote the very anti-pattern the
+    static guards below search for."""
+    return "\n".join(
+        line for line in shell.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+# ── Static guards ──────────────────────────────────────────────────────────
+
+
+def test_step_never_passes_output_or_summary_via_argv():
+    body = code_only(bash_function("step"))
+    assert '--arg o ' not in body, (
+        "step() must not pass $output as a jq command-line argument — "
+        f"execve caps one argument at {MAX_ARG_STRLEN} bytes and a real "
+        "plan/apply log is far bigger. Use --rawfile."
+    )
+    assert '--arg j ' not in body, "step() must not pass $summary via argv either"
+    assert "--rawfile o " in body and "--data-binary @" in body
+
+
+def test_stream_step_output_never_passes_output_via_argv():
+    body = code_only(bash_function("stream_step_output"))
+    assert '--arg o ' not in body, (
+        "the live-output streamer must not pass the log tail via argv; the "
+        "tail cap is not a safe place to rely on"
+    )
+    assert "--rawfile o " in body and "--data-binary @" in body
+
+
+def test_opa_summary_findings_do_not_go_through_argv():
+    src = code_only(entrypoint_source())
+    assert '--argjson failures ' not in src, (
+        "OPA findings arrays can exceed MAX_ARG_STRLEN on a large plan; "
+        "pass them with --slurpfile"
+    )
+    assert "--slurpfile failures " in src
+
+
+def test_executor_reports_its_own_unexpected_death():
+    """The reaper is the backstop, not the error channel."""
+    src = entrypoint_source()
+    assert "trap on_exit EXIT" in src, (
+        "an EXIT trap is the only hook that survives `set -e` firing inside a "
+        "function (bash skips ERR traps there without errtrace)"
+    )
+    body = bash_function("on_exit")
+    assert "TERMINAL_STATUS_REPORTED" in body, (
+        "on_exit must not relabel a run that already reported a terminal status"
+    )
+    assert "report_status" in body
+    # SIGINT/SIGTERM = an operator cancelling the run; that run is already
+    # `cancelled` and must not be relabelled `failed`.
+    assert "130" in body and "143" in body
+
+
+# ── Functional: drive the real step() with an oversized payload ────────────
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="needs bash + jq (both are in the executor image)",
+)
+@pytest.mark.parametrize("summary", ["", '{"add":139,"change":0,"destroy":0}'])
+def test_step_survives_a_payload_far_past_the_argv_limit(tmp_path, summary):
+    """1 MB of step output must produce a well-formed PATCH body, not exit 126.
+
+    Runs the *real* `step()` lifted out of entrypoint.sh under the same
+    `set -euo pipefail` the executor uses, with curl stubbed out so we can
+    inspect the body it would have sent.
+    """
+    payload_len = 1024 * 1024
+    assert payload_len > MAX_ARG_STRLEN
+
+    harness = tmp_path / "harness.sh"
+    captured = tmp_path / "body.json"
+    harness.write_text(
+        "#!/bin/bash\n"
+        "set -euo pipefail\n"
+        'API_URL="http://stub"; API_TOKEN="t"; RUN_ID="r"\n'
+        # Stub curl: keep the body file the real step() built.
+        "curl() {\n"
+        '  local a; for a in "$@"; do\n'
+        '    case "$a" in --data-binary@*|--data-binary) ;; @*) cp "${a#@}" '
+        f'"{captured}" ;;\n'
+        "    esac\n"
+        "  done\n"
+        "  return 0\n"
+        "}\n"
+        # Stub the steps lookup so step() finds an id without an API.
+        'step_id_for() { echo "step-1"; }\n'
+        f"{bash_function('step')}\n"
+        f'output=$(head -c {payload_len} /dev/zero | tr "\\0" "x")\n'
+        f'step "Terraform Plan" success "$output" {summary!r}\n'
+        'echo "SURVIVED"\n'
+    )
+
+    proc = subprocess.run(
+        ["bash", str(harness)], capture_output=True, text=True, timeout=120
+    )
+    assert proc.returncode == 0, (
+        f"step() died (rc={proc.returncode}) on a {payload_len}-byte output.\n"
+        f"stderr: {proc.stderr[:2000]}"
+    )
+    assert "SURVIVED" in proc.stdout
+    # 126 is bash's "found it but could not execute it" — the old symptom.
+    assert "Argument list too long" not in proc.stderr
+
+    import json
+
+    body = json.loads(captured.read_text())
+    assert body["status"] == "success"
+    assert len(body["output"]) == payload_len, "the full log must reach the API"
+    if summary:
+        assert body["summary_json"] == summary
+    else:
+        # Unchanged from before the fix: the no-summary branch omits the key
+        # rather than sending an explicit null.
+        assert "summary_json" not in body
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="needs bash + jq",
+)
+def test_the_old_argv_form_really_did_die_silently(tmp_path):
+    """Characterise the bug so the fix above can't be undone as cosmetic.
+
+    Proves both halves of the production failure: bash aborts with 126, and
+    the ERR trap does NOT fire because the failure is inside a function.
+    """
+    harness = tmp_path / "old.sh"
+    harness.write_text(
+        "#!/bin/bash\n"
+        "set -euo pipefail\n"
+        "trap 'echo ERR_TRAP_FIRED' ERR\n"
+        "old_step() {\n"
+        '  local output="$1"\n'
+        "  local body\n"
+        "  body=$(jq -n --arg o \"$output\" '{output:$o}')\n"
+        '  echo "REACHED_CURL"\n'
+        "}\n"
+        f'big=$(head -c {MAX_ARG_STRLEN + 4096} /dev/zero | tr "\\0" "x")\n'
+        'old_step "$big"\n'
+        "echo REACHED_END\n"
+    )
+    proc = subprocess.run(
+        ["bash", str(harness)], capture_output=True, text=True, timeout=120
+    )
+    assert proc.returncode == 126, f"expected exit 126, got {proc.returncode}"
+    assert "Argument list too long" in proc.stderr
+    assert "REACHED_CURL" not in proc.stdout
+    assert "ERR_TRAP_FIRED" not in proc.stdout, (
+        "if bash ever starts firing ERR traps inside functions without "
+        "errtrace, on_unexpected_err would have caught this in production"
+    )
+
+
+# ── Functional: the EXIT-trap backstop ────────────────────────────────────
+
+
+def _exit_trap_harness(tmp_path, api_status: str, boom: str) -> tuple:
+    """Build a harness that runs the real report_status() + on_exit() with a
+    stubbed API, then dies the way production died: nonzero inside a function,
+    where bash skips the ERR trap.
+    """
+    recorded = tmp_path / "patched.json"
+    harness = tmp_path / "exit.sh"
+    harness.write_text(
+        "#!/bin/bash\n"
+        "set -euo pipefail\n"
+        'API_URL="http://stub"; API_TOKEN="t"; RUN_ID="r"\n'
+        "curl() {\n"
+        '  local a is_patch=0 body=""\n'
+        '  for a in "$@"; do\n'
+        '    [[ "$a" == "PATCH" ]] && is_patch=1\n'
+        '    case "$a" in @*) body="${a#@}" ;; esac\n'
+        "  done\n"
+        '  if [[ "$is_patch" == "1" ]]; then\n'
+        f'    [[ -n "$body" ]] && cp "$body" "{recorded}"\n'
+        "  else\n"
+        f"    printf '%s' '{{\"status\":\"{api_status}\"}}'\n"
+        "  fi\n"
+        "  return 0\n"
+        "}\n"
+        f"{bash_function('report_status')}\n"
+        f"{bash_function('on_exit')}\n"
+        "TERMINAL_STATUS_REPORTED=0\n"
+        "HEARTBEAT_PID=\n"
+        "trap on_exit EXIT\n"
+        # The production shape: `set -e` fires inside a function, so the ERR
+        # trap never runs and on_unexpected_err never reports.
+        f"{boom}\n"
+        "boom\n"
+        "echo REACHED_END\n"
+    )
+    proc = subprocess.run(
+        ["bash", str(harness)], capture_output=True, text=True, timeout=60
+    )
+    return proc, recorded
+
+
+BOOM = 'boom() {\n  local x\n  x=$(exit 7)\n  echo NOT_REACHED\n}'
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="needs bash + jq",
+)
+def test_exit_trap_reports_a_silent_death_instead_of_waiting_for_the_reaper(
+    tmp_path,
+):
+    proc, recorded = _exit_trap_harness(tmp_path, "running", BOOM)
+
+    assert "REACHED_END" not in proc.stdout, "the harness must really die"
+    assert recorded.exists(), (
+        "on_exit must PATCH the run failed; without it the run sits in "
+        "`running` until the reaper times it out"
+    )
+    import json
+
+    body = json.loads(recorded.read_text())
+    assert body["status"] == "failed"
+    assert "exited unexpectedly (exit=7)" in body["plan_output"]
+
+
+@pytest.mark.skipif(
+    shutil.which("bash") is None or shutil.which("jq") is None,
+    reason="needs bash + jq",
+)
+@pytest.mark.parametrize("api_status", ["awaiting_approval", "planned", "applied"])
+def test_exit_trap_never_relabels_a_run_the_api_already_finished(
+    tmp_path, api_status
+):
+    """The plan phase writes `planned` / `awaiting_approval` with its own curl
+    (those bodies carry plan_json + the tfplan blob), so the local flag alone
+    can't be trusted — on_exit must ask the API before overwriting."""
+    _proc, recorded = _exit_trap_harness(tmp_path, api_status, BOOM)
+    assert not recorded.exists(), (
+        f"on_exit relabelled a run already at {api_status!r} as failed"
+    )
+
+
+# ── The other half of the contract: the API accepts what we now send ──────
+
+
+@pytest.mark.asyncio
+async def test_api_stores_a_step_output_far_past_the_argv_limit(
+    auth_client, seeded_users, default_aws_account, _setup_db
+):
+    """Fixing the executor is only half of it — the API has to take the body.
+
+    Pins that there is no request-size cap in the router and no truncation on
+    the way to the column, so a future body-size limit can't silently
+    reintroduce the wedge.
+    """
+    import uuid
+
+    from app.models.business_unit import DEFAULT_BU_ID
+    from app.models.workspace import Workspace
+
+    factory = _setup_db
+    ws_id = str(uuid.uuid4())
+    async with factory() as session:
+        session.add(
+            Workspace(
+                business_unit_id=DEFAULT_BU_ID,
+                id=ws_id,
+                name="bigplan",
+                aws_account_id="123456789012",
+                region="us-east-1",
+                environment="dev",
+                tf_working_dir=".",
+                repo_url="https://example.com/x.git",
+            )
+        )
+        await session.commit()
+
+    token = (
+        await auth_client.post(
+            "/api/v1/auth/token",
+            json={"email": "operator@test.com", "password": "password123"},
+        )
+    ).json()["access_token"]
+    auth = {"Authorization": f"Bearer {token}"}
+
+    run_id = (
+        await auth_client.post(
+            f"/api/v1/workspaces/{ws_id}/runs", json={"command": "plan"}, headers=auth
+        )
+    ).json()["id"]
+    steps = (
+        await auth_client.get(f"/api/v1/runs/{run_id}/steps", headers=auth)
+    ).json()
+    step_id = steps[0]["id"]
+
+    # 2 MB — 16x the old argv cliff, the order of magnitude a 139-resource
+    # plan actually produces.
+    output = "x" * (2 * 1024 * 1024)
+    r = await auth_client.patch(
+        f"/api/v1/runs/{run_id}/steps/{step_id}",
+        json={"status": "success", "output": output, "summary_json": '{"add":139}'},
+        headers=auth,
+    )
+    assert r.status_code == 200, r.text
+    assert len(r.json()["output"]) == len(output)
+
+    # And it survives the round trip out of the column.
+    back = await auth_client.get(f"/api/v1/runs/{run_id}/steps", headers=auth)
+    stored = next(s for s in back.json() if s["id"] == step_id)
+    assert len(stored["output"]) == len(output)
+    assert stored["summary_json"] == '{"add":139}'

--- a/services/api/tests/test_run_worker.py
+++ b/services/api/tests/test_run_worker.py
@@ -227,7 +227,8 @@ async def test_reap_stale_fails_old_picked_jobs(db_session):
     await db_session.refresh(run)
     await db_session.refresh(job)
     assert run.status == RunStatus.FAILED
-    assert "no heartbeat" in (run.error_output or "")
+    assert "without a heartbeat" in (run.error_output or "")
+    assert "never finished handing the job to an executor" in (run.error_output or "")
     assert job.state == RunJobState.FAILED
 
 
@@ -274,7 +275,10 @@ async def test_reap_stale_reaps_done_job_with_non_terminal_run(db_session):
     await db_session.refresh(run)
     await db_session.refresh(job)
     assert run.status == RunStatus.FAILED
-    assert "executor died" in (run.error_output or "")
+    # The DONE branch must point the reader at the executor's own log —
+    # this reason is the only breadcrumb a stuck run leaves behind.
+    assert "stopped sending heartbeats" in (run.error_output or "")
+    assert "executor container/task log" in (run.error_output or "")
     assert job.state == RunJobState.FAILED
 
 

--- a/services/executor/entrypoint.sh
+++ b/services/executor/entrypoint.sh
@@ -65,9 +65,16 @@ export GIT_TERMINAL_PROMPT="0"
 # ---------------------------------------------------------------------------
 # report_status: PATCH the run-level status (running/planned/applied/failed).
 # ---------------------------------------------------------------------------
+# Flipped to 1 by report_status() once the run reaches a terminal state, so
+# the EXIT trap can tell "finished and said so" from "died silently".
+TERMINAL_STATUS_REPORTED=0
+
 report_status() {
   local status="$1"
   local output="${2:-}"
+  case "${status}" in
+    planned|awaiting_approval|applied|failed|cancelled) TERMINAL_STATUS_REPORTED=1 ;;
+  esac
   # Build the body via a file so neither $output nor the full body bloats the
   # command line past ARG_MAX (terraform apply on a real stack can produce
   # several MB of output).
@@ -112,18 +119,36 @@ step() {
   local sid
   sid=$(step_id_for "$name")
   if [[ -z "$sid" ]]; then return 0; fi
-  local body
+  # Build the body through FILES, never argv — same reason report_status() and
+  # the run-level PATCH below do. execve caps a *single* argument at
+  # MAX_ARG_STRLEN (128 KB on Linux) no matter how large ARG_MAX is, so
+  # `jq --arg o "$output"` dies with "Argument list too long" the moment a
+  # plan/apply log crosses 128 KB — which any real stack does.
+  #
+  # That failure is worse than a lost timeline row: it happens INSIDE this
+  # function, and bash does not run the ERR trap for failures inside functions
+  # unless errtrace (`set -E`) is on — it isn't. So `set -e` killed the
+  # executor at exit 126 with on_unexpected_err never firing: nothing was
+  # reported, the run sat in `running`, and the API reaper failed it
+  # `worker.stale_after_seconds` later with a generic "executor died before
+  # reporting any step status". Raising that dial only delays the reap.
+  printf '%s' "${output}" > /tmp/_step_out.txt
   if [[ -n "$summary" ]]; then
-    body=$(jq -n --arg s "$status" --arg o "$output" --arg j "$summary" \
-      '{status:$s, output:(if $o=="" then null else $o end), summary_json:(if $j=="" then null else $j end)}')
+    printf '%s' "${summary}" > /tmp/_step_summary.json
+    jq -n --arg s "$status" \
+      --rawfile o /tmp/_step_out.txt \
+      --rawfile j /tmp/_step_summary.json \
+      '{status:$s, output:(if $o=="" then null else $o end), summary_json:(if $j=="" then null else $j end)}' \
+      > /tmp/_step_body.json
   else
-    body=$(jq -n --arg s "$status" --arg o "$output" \
-      '{status:$s, output:(if $o=="" then null else $o end)}')
+    jq -n --arg s "$status" --rawfile o /tmp/_step_out.txt \
+      '{status:$s, output:(if $o=="" then null else $o end)}' \
+      > /tmp/_step_body.json
   fi
   curl -sf -X PATCH "${API_URL}/api/v1/runs/${RUN_ID}/steps/${sid}" \
     -H "Authorization: Bearer ${API_TOKEN}" \
     -H "Content-Type: application/json" \
-    -d "${body}" > /dev/null || echo "WARNING: step '$name' → '$status' patch failed" >&2
+    --data-binary @/tmp/_step_body.json > /dev/null || echo "WARNING: step '$name' → '$status' patch failed" >&2
 }
 
 # Wrap a phase: marks running before, success/failed after; captures stdout into
@@ -161,12 +186,19 @@ stream_step_output() {
       local current
       current=$(tail -c "$tail_size" "$log_file" 2>/dev/null || true)
       if [[ -n "$current" ]]; then
-        local body
-        body=$(jq -n --arg s "running" --arg o "$current" '{status:$s, output:$o}')
+        # Files, not argv — see step(). The tail cap above keeps us under
+        # MAX_ARG_STRLEN today, but this way raising tail_size can never
+        # reintroduce the crash. $BASHPID (not $$) so this background
+        # subshell never shares a temp file with the foreground step().
+        local out_file="/tmp/_stream_out.${BASHPID}.txt"
+        local body_file="/tmp/_stream_body.${BASHPID}.json"
+        printf '%s' "$current" > "$out_file"
+        jq -n --arg s "running" --rawfile o "$out_file" \
+          '{status:$s, output:$o}' > "$body_file"
         curl -sf -X PATCH "${API_URL}/api/v1/runs/${RUN_ID}/steps/${sid}" \
           -H "Authorization: Bearer ${API_TOKEN}" \
           -H "Content-Type: application/json" \
-          -d "$body" > /dev/null 2>&1 || true
+          --data-binary @"$body_file" > /dev/null 2>&1 || true
       fi
     fi
     sleep 1.5
@@ -348,12 +380,18 @@ run_opa_policy_check() {
   fi
 
   # Structured summary for the timeline badge + RunDetail Policies tab.
+  # $failures / $warnings are whole JSON arrays of findings — on a large plan
+  # they too can exceed MAX_ARG_STRLEN, so they go through files (--slurpfile
+  # wraps each file's value in an array, hence the [0]). See step().
   local summary
+  printf '%s' "$failures" > /tmp/_opa_failures.json
+  printf '%s' "$warnings" > /tmp/_opa_warnings.json
   summary=$(jq -n \
     --arg mode "$mode" --arg status "$status" \
-    --argjson failures "$failures" --argjson warnings "$warnings" \
+    --slurpfile failures /tmp/_opa_failures.json \
+    --slurpfile warnings /tmp/_opa_warnings.json \
     --argjson fc "$fail_count" --argjson wc "$warn_count" --argjson bc "$block_count" \
-    '{mode:$mode, status:$status, violations:$failures, warnings:$warnings,
+    '{mode:$mode, status:$status, violations:$failures[0], warnings:$warnings[0],
       counts:{failures:$fc, warnings:$wc, blocking:$bc}}')
 
   # Human-readable output.
@@ -469,8 +507,50 @@ heartbeat_loop() {
 }
 heartbeat_loop &
 HEARTBEAT_PID=$!
-# shellcheck disable=SC2064
-trap "kill ${HEARTBEAT_PID} 2>/dev/null || true" EXIT
+
+# Backstop for a silent death. `set -e` firing inside a shell function does NOT
+# run the ERR trap (errtrace is off), so on_unexpected_err can be skipped
+# entirely — that is exactly how an argv-too-long jq call used to kill this
+# script with nothing reported, leaving the run in `running` until the API
+# reaper failed it minutes later with a generic message. If we are exiting
+# nonzero and have not reported a terminal status, say so ourselves.
+on_exit() {
+  local rc=$?
+  # Nothing below may abort this trap — it is the last thing that can tell
+  # the API anything, so it runs without errexit/ERR.
+  set +e
+  trap - ERR
+  kill "${HEARTBEAT_PID:-}" 2>/dev/null || true
+
+  # Clean exit, or we already said something terminal → nothing to add.
+  [[ "${rc}" -eq 0 ]] && return 0
+  [[ "${TERMINAL_STATUS_REPORTED}" == "1" ]] && return 0
+  # 130/143 = SIGINT/SIGTERM, i.e. `POST /runs/{id}/cancel` stopping the
+  # container. That run is already `cancelled`; don't relabel it failed.
+  { [[ "${rc}" -eq 130 ]] || [[ "${rc}" -eq 143 ]]; } && return 0
+
+  # Authoritative guard for the terminal PATCHes that bypass report_status
+  # (the plan phase writes `planned` / `awaiting_approval` with its own curl,
+  # because those bodies carry plan_json + the tfplan blob). Never relabel a
+  # run the API already considers finished or paused for approval.
+  local current
+  current=$(curl -sf -H "Authorization: Bearer ${API_TOKEN}" \
+    "${API_URL}/api/v1/runs/${RUN_ID}" 2>/dev/null | jq -r '.status' 2>/dev/null)
+  case "${current}" in
+    planned|awaiting_approval|applied|failed|cancelled) return 0 ;;
+  esac
+
+  local f log="" tail_out=""
+  for f in /tmp/apply.log /tmp/plan.log /tmp/init.log /tmp/checkov.log; do
+    if [[ -s "$f" ]]; then log="$f"; break; fi
+  done
+  if [[ -n "$log" ]]; then
+    tail_out=$'\n--- '"$log"$' (last 40 lines) ---\n'"$(tail -n 40 "$log")"
+  fi
+  report_status "failed" \
+    "Executor exited unexpectedly (exit=${rc}) without reporting a terminal status.${tail_out}"
+}
+trap on_exit EXIT
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Helm pipeline (WORKSPACE_KIND=helm). Reuses the same run_step()/stream_run()/


### PR DESCRIPTION
## The bug

A run on a workspace with a large plan fails every time, and the only trace in
the UI is the reaper:

> Run reaped after 600s — executor died before reporting any step status

Raising `worker.stale_after_seconds` changes *when* it dies, nothing else. The
executor log has the real cause:

```
/entrypoint.sh: line 121: /usr/bin/jq: Argument list too long
WARNING: step 'Terraform Plan' → 'success' patch failed
/entrypoint.sh: line 118: /usr/bin/jq: Argument list too long
```

…then silence. No heartbeat, task gone, and memory nowhere near the limit — so
it isn't an OOM.

`step()` handed the whole plan/apply log to `jq` as a command-line argument
(`jq --arg o "$output"`). `execve` caps a **single argument at
`MAX_ARG_STRLEN`** — 128 KB on Linux, whatever `ARG_MAX` says (verified: 127
KiB works, 128 KiB fails). Any real stack's plan crosses that, so jq never
starts.

Two things make it lethal rather than merely lossy:

1. The failure happens **inside a shell function**, and bash skips the `ERR`
   trap for failures inside functions unless errtrace (`set -E`) is on — it
   isn't. So `set -e` killed the executor at exit 126 and `on_unexpected_err`
   never fired. Nothing was reported.
2. With no status and no heartbeat, the run sat in `running` until the reaper
   failed it — which is the only message the operator ever saw.

Only workspaces with large plans are affected, which makes this look
environment-specific. The same ARG_MAX bug had already been fixed for the
*run-level* PATCH (see the comment above the `planned` PATCH); the
*step-level* one was missed in that pass.

## The fix

- `step()`, `stream_step_output()` and the OPA findings summary build their
  bodies through files (`--rawfile` / `--slurpfile` + `curl --data-binary @`),
  the way `report_status()` and the run-level PATCH already did.
- `trap on_exit EXIT` reports `failed` with the log tail when the script exits
  nonzero without having reported a terminal status — the EXIT trap is the only
  hook that survives errexit firing inside a function. Skipped on
  SIGINT/SIGTERM (an operator cancelling), and gated on a status GET so a run
  the API already finished or paused for approval is never relabelled.
- The reaper's DONE-branch message no longer claims "died before reporting any
  step status" — steps may well have reported before the executor exited. It
  now gives the heartbeat age and points at the executor's own log.

## Tests

`services/api/tests/test_executor_step_payload.py` (12 tests): static guards
against the argv form; a 1 MB functional run of the real `step()` lifted out of
`entrypoint.sh`; both EXIT-trap paths (reports a silent death / never relabels
a finished run); a characterisation test pinning that the old form dies at 126
with the ERR trap skipped, so the fix can't be undone as cosmetic; and a 2 MB
step PATCH round-tripping through the API, since fixing the executor only helps
if the API takes the body.

Full API suite: **656 passed, 8 skipped**.

Also verified inside the built executor image itself — its own `/entrypoint.sh`
`step()` handles 127 KiB, 128 KiB (the old cliff), 1 MiB and 4 MiB, each
producing a correct body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
